### PR TITLE
fix: remove javascript from email template

### DIFF
--- a/src/main/java/eu/bbmri_eric/negotiator/service/EmailServiceImpl.java
+++ b/src/main/java/eu/bbmri_eric/negotiator/service/EmailServiceImpl.java
@@ -93,6 +93,6 @@ public class EmailServiceImpl implements EmailService {
     }
     notificationEmail.setWasSuccessfullySent(true);
     notificationEmailRepository.save(notificationEmail);
-    log.info("Email message sent.");
+    log.debug("Email message sent.");
   }
 }

--- a/src/main/java/eu/bbmri_eric/negotiator/service/EmailServiceImpl.java
+++ b/src/main/java/eu/bbmri_eric/negotiator/service/EmailServiceImpl.java
@@ -5,7 +5,6 @@ import eu.bbmri_eric.negotiator.database.model.Person;
 import eu.bbmri_eric.negotiator.database.repository.NotificationEmailRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import java.io.UnsupportedEncodingException;
 import java.util.Objects;
 import java.util.regex.Pattern;
 import lombok.NonNull;
@@ -51,11 +50,9 @@ public class EmailServiceImpl implements EmailService {
       helper.setText(mailBody, true);
       helper.setTo(recipientAddress);
       helper.setSubject(subject);
-      helper.setFrom("noreply@bbmri-eric.eu", "BBMRI-ERIC Negotiator");
+      helper.setFrom("BBMRI-ERIC Negotiator <noreply@bbmri-eric.eu>");
     } catch (MessagingException e) {
       throw new NullPointerException(e.toString());
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
     }
     return mimeMessage;
   }

--- a/src/main/java/eu/bbmri_eric/negotiator/service/UserNotificationServiceImpl.java
+++ b/src/main/java/eu/bbmri_eric/negotiator/service/UserNotificationServiceImpl.java
@@ -34,7 +34,7 @@ public class UserNotificationServiceImpl implements UserNotificationService {
   @Autowired TemplateEngine templateEngine;
 
   @Value("${negotiator.frontend-url}")
-  private String frontendurl;
+  private String frontendUrl;
 
   private static Set<Resource> getResourcesInNegotiationRepresentedBy(
       Negotiation negotiation, Person representative) {
@@ -264,7 +264,7 @@ public class UserNotificationServiceImpl implements UserNotificationService {
     Map<String, String> titleForNegotiation = populateTitleForNegotiationMap(notifications);
 
     context.setVariable("negotiations", negotiations);
-    context.setVariable("frontendurl", frontendurl);
+    context.setVariable("frontendurl", frontendUrl);
     context.setVariable("roleForNegotiation", roleForNegotiation);
     context.setVariable("titleForNegotiation", titleForNegotiation);
 

--- a/src/main/java/eu/bbmri_eric/negotiator/service/UserNotificationServiceImpl.java
+++ b/src/main/java/eu/bbmri_eric/negotiator/service/UserNotificationServiceImpl.java
@@ -288,17 +288,22 @@ public class UserNotificationServiceImpl implements UserNotificationService {
     for (Notification notification : notifications) {
       Negotiation negotiation = notification.getNegotiation();
       String negotiatorId = negotiation.getId();
-      String title;
-      try {
-        JSONObject payloadJson = new JSONObject(negotiation.getPayload());
-        title = payloadJson.getJSONObject("project").getString("title");
-      } catch (JSONException e) {
-        log.error("Failed to extract title from payload JSON", e);
-        title = "Untitled negotiation";
-      }
+      String title = parseTitleFromNegotiation(negotiation);
       titleForNegotiation.put(negotiatorId, title);
     }
     return titleForNegotiation;
+  }
+
+  private static String parseTitleFromNegotiation(Negotiation negotiation) {
+    String title;
+    try {
+      JSONObject payloadJson = new JSONObject(negotiation.getPayload());
+      title = payloadJson.getJSONObject("project").getString("title");
+    } catch (JSONException e) {
+      log.error("Failed to extract title from payload JSON", e);
+      title = "Untitled negotiation";
+    }
+    return title;
   }
 
   private String extractRoleFromNotificationMessage(Notification notification) {

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -58,7 +58,7 @@ negotiator:
     subject-claim: "sub"
     resource-claim-prefix: "urn:geant:bbmri-eric.eu:group:bbmri:collections:BBMRI-ERIC%20Directory:"
 notification:
-  cron-schedule-expression: "0 */5 * ? * *"
+  cron-schedule-expression: "0 * * * * *"
 logging:
   level:
     org.springframeworf.web: debug

--- a/src/main/resources/templates/email-notification.html
+++ b/src/main/resources/templates/email-notification.html
@@ -70,13 +70,7 @@
                             <!-- Loop through notifications and display them -->
                             <li th:each="negotiation : ${negotiations}">
                                 <a th:href="@{${frontendurl} + '/negotiations/' + ${negotiation.id} + '/'+ ${roleForNegotiation.get(negotiation.id)}}">
-                                    <script th:inline="javascript">
-                                        /* Parse the JSON string into a JSON object */
-                                        var payloadJson = JSON.parse(/*[[${negotiation.payload}]]*/);
-                                        var projectTitle = payloadJson?.project?.title;
-                                        document.write(projectTitle);
-                                    </script>
-
+                                    <span th:utext="${titleForNegotiation.get(negotiation.id)}"></span>
                                 </a>
                             </li>
                         </ul>

--- a/src/main/resources/templates/email-notification.html
+++ b/src/main/resources/templates/email-notification.html
@@ -4,7 +4,7 @@
         <style>
             .email-notifications {
                 background-color: #ffffff;
-                font-family: "Open Sans-Regular", Helvetica;
+                font-family: "Open Sans-Regular", Helvetica, sans-serif;
                 color: #333333;
                 width:70%;
                 margin: 0 auto;
@@ -23,13 +23,6 @@
 
             .email-notifications .logo-bbmri {
                 width: 190px;
-            }
-
-            .email-notifications .text-negotiator {
-                font-size: 20px;
-                text-transform: uppercase;
-                align-self: center;
-                padding-bottom: 15px;
             }
 
             .email-notifications hr {
@@ -57,7 +50,6 @@
         <div class="email-notifications">
             <div class="email-header">
                 <img class="logo-bbmri" th:src="@{${frontendurl} + '/api/images/2023-BBMRI-ERIC-Logo_NEGOTIATOR.png'}" alt="BBMRI-ERIC Logo"/>
-<!--                <div class="text-negotiator">Negotiator</div>-->
             </div>
             <hr />
             <div class="email-content">


### PR DESCRIPTION
## Negotiator pull request:

### Description:

Removed javascript from email template. So the title is correctly shown in email clients such as outlook.

### Checklist:

_Make sure you tick all the boxes bellow if they are true or do not apply:_

- [x] I have performed a self review of my code
- [x] My code follows [Google Java Code style](https://google.github.io/styleguide/javaguide.html)
- [x] I have made my code as simple as possible
- [x] I have added unit tests and the code coverage has not decreased
- [x] I have updated the documentation in all relevant places
