### PR TITLE
Add an /info endpoint for getting basic application details

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,11 @@
     <groupId>eu.bbmri_eric</groupId>
     <artifactId>negotiator</artifactId>
     <name>BBMRI-ERIC Negotiator</name>
-    <version>3.0.1</version>
+    <version>3.1.4</version>
     <packaging>jar</packaging>
     <description>
         An open-source access negotiation tool for research infrastructures.
     </description>
-
     <parent>
         <artifactId>spring-boot-starter-parent</artifactId>
         <groupId>org.springframework.boot</groupId>
@@ -27,6 +26,7 @@
     <build>
         <finalName>negotiator</finalName>
         <plugins>
+
             <plugin>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <executions>
@@ -78,6 +78,7 @@
                         </configuration>
                         <goals>
                             <goal>repackage</goal>
+                            <goal>build-info</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -145,6 +146,11 @@
         <dependency>
             <artifactId>spring-boot-starter</artifactId>
             <groupId>org.springframework.boot</groupId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
             <version>${spring-boot.version}</version>
         </dependency>
         <dependency>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,19 +1,27 @@
+
 server:
   port: 8081
   servlet:
     context-path: "/api"
 management:
   endpoint:
+    info:
+      enabled: true
     health:
       enabled: true
       show-components: always
+  info:
+    env:
+      enabled: true
+    build:
+      enabled: true
   health:
     db:
       enabled: true
   endpoints:
     web:
       exposure:
-        include: health
+        include: "health,info"
 spring:
   mail:
     host: "localhost"
@@ -63,3 +71,11 @@ logging:
     root: info
 springdoc:
   show-actuator: true
+info:
+  application:
+    name: "BBMRI-ERIC Negotiator"
+    description: "An Open-source access negotiation system for Research Infrastructures."
+    environment: "Production"
+    license:
+      name: "GNU Affero General Public License v3.0"
+      url: "https://www.gnu.org/licenses/agpl-3.0.en.html#license-text"


### PR DESCRIPTION
## Negotiator pull request:

### Description:

Adds an /info endpoint for getting basic application details. To test it, spin up the application and go to http://localhost:8081/api/actuator/info.

### Checklist:

_Make sure you tick all the boxes bellow if they are true or do not apply:_

- [x] I have performed a self review of my code
- [x] My code follows [Google Java Code style](https://google.github.io/styleguide/javaguide.html)
- [x] I have made my code as simple as possible
- [x] I have added unit tests and the code coverage has not decreased
- [x] I have updated the documentation in all relevant places
