### PR TITLE
Add a simple cache for OAuth2 token validation

### DIFF
--- a/src/main/java/eu/bbmri_eric/negotiator/configuration/security/OAuthSecurityConfig.java
+++ b/src/main/java/eu/bbmri_eric/negotiator/configuration/security/OAuthSecurityConfig.java
@@ -6,6 +6,7 @@ import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
 import eu.bbmri_eric.negotiator.configuration.ExceptionHandlerFilter;
 import eu.bbmri_eric.negotiator.configuration.security.auth.CustomJWTAuthConverter;
+import eu.bbmri_eric.negotiator.configuration.security.auth.IntrospectionValidator;
 import eu.bbmri_eric.negotiator.configuration.security.auth.NegotiatorUserDetailsService;
 import eu.bbmri_eric.negotiator.database.repository.PersonRepository;
 import java.util.List;
@@ -25,6 +26,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtClaimValidator;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
@@ -183,7 +185,10 @@ public class OAuthSecurityConfig {
   private void addTokenValidators(NimbusJwtDecoder decoder) {
     decoder.setJwtValidator(
         new DelegatingOAuth2TokenValidator<>(
-            introspectionValidator(), new JwtIssuerValidator(jwtIssuer), audienceValidator()));
+            introspectionValidator(),
+            new JwtIssuerValidator(jwtIssuer),
+            audienceValidator(),
+            new JwtTimestampValidator()));
   }
 
   @Bean

--- a/src/main/java/eu/bbmri_eric/negotiator/configuration/security/auth/CacheManager.java
+++ b/src/main/java/eu/bbmri_eric/negotiator/configuration/security/auth/CacheManager.java
@@ -1,0 +1,16 @@
+package eu.bbmri_eric.negotiator.configuration.security.auth;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+public class CacheManager {
+
+  @Scheduled(cron = "0 */5 * ? * *")
+  @Async
+  protected void clearCache() {
+    CustomJWTAuthConverter.cleanCache();
+    IntrospectionValidator.cleanCache();
+  }
+}

--- a/src/main/java/eu/bbmri_eric/negotiator/configuration/security/auth/CustomJWTAuthConverter.java
+++ b/src/main/java/eu/bbmri_eric/negotiator/configuration/security/auth/CustomJWTAuthConverter.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.AllArgsConstructor;
 import lombok.extern.apachecommons.CommonsLog;
 import org.springframework.core.convert.converter.Converter;
@@ -42,6 +43,9 @@ public class CustomJWTAuthConverter implements Converter<Jwt, AbstractAuthentica
   private final String authzResearcherValue;
 
   private final String authzBiobankerValue;
+
+  private static final Map<String, LinkedHashMap<String, Object>> userInfoCache =
+      new ConcurrentHashMap<>();
 
   @Override
   public final AbstractAuthenticationToken convert(Jwt jwt) {
@@ -130,6 +134,10 @@ public class CustomJWTAuthConverter implements Converter<Jwt, AbstractAuthentica
   }
 
   private Map<String, Object> getClaims(Jwt jwt) {
+    if (userInfoCache.containsKey(jwt.getSubject())) {
+      log.debug(userInfoCache.keySet().size());
+      return userInfoCache.get(jwt.getSubject());
+    }
     if (userInfoEndpoint != null
         && !userInfoEndpoint.isBlank()
         && jwt.getClaimAsString("scope").contains("openid")) {
@@ -142,6 +150,7 @@ public class CustomJWTAuthConverter implements Converter<Jwt, AbstractAuthentica
   private LinkedHashMap<String, Object> getClaimsFromUserEndpoints(Jwt jwt) {
     Object claims = requestClaimsFromUserInfoEndpoint(jwt);
     try {
+      userInfoCache.put(jwt.getSubject(), (LinkedHashMap<String, Object>) claims);
       return (LinkedHashMap<String, Object>) claims;
     } catch (ClassCastException ex) {
       return new LinkedHashMap<>();
@@ -180,5 +189,10 @@ public class CustomJWTAuthConverter implements Converter<Jwt, AbstractAuthentica
     }
     log.info(String.format("User with sub: %s added to the database", person.getSubjectId()));
     return person;
+  }
+
+  static void cleanCache() {
+    log.debug("Clearing userInfo cache.");
+    userInfoCache.clear();
   }
 }

--- a/src/main/java/eu/bbmri_eric/negotiator/configuration/security/auth/CustomJWTAuthConverter.java
+++ b/src/main/java/eu/bbmri_eric/negotiator/configuration/security/auth/CustomJWTAuthConverter.java
@@ -135,7 +135,6 @@ public class CustomJWTAuthConverter implements Converter<Jwt, AbstractAuthentica
 
   private Map<String, Object> getClaims(Jwt jwt) {
     if (userInfoCache.containsKey(jwt.getSubject())) {
-      log.debug(userInfoCache.keySet().size());
       return userInfoCache.get(jwt.getSubject());
     }
     if (userInfoEndpoint != null
@@ -149,12 +148,15 @@ public class CustomJWTAuthConverter implements Converter<Jwt, AbstractAuthentica
 
   private LinkedHashMap<String, Object> getClaimsFromUserEndpoints(Jwt jwt) {
     Object claims = requestClaimsFromUserInfoEndpoint(jwt);
+    LinkedHashMap<String, Object> mappedClaims;
     try {
-      userInfoCache.put(jwt.getSubject(), (LinkedHashMap<String, Object>) claims);
-      return (LinkedHashMap<String, Object>) claims;
+      mappedClaims = (LinkedHashMap<String, Object>) claims;
     } catch (ClassCastException ex) {
       return new LinkedHashMap<>();
     }
+    userInfoCache.put(jwt.getSubject(), mappedClaims);
+    log.info("USER_LOGIN: User %s logged in.".formatted(mappedClaims.get("name")));
+    return mappedClaims;
   }
 
   private Object requestClaimsFromUserInfoEndpoint(Jwt jwt) {


### PR DESCRIPTION
## Negotiator pull request:

### Description:

Adds a cache for userinfo and token introspection that is emptied every 5 minutes. 

### Checklist:

_Make sure you tick all the boxes bellow if they are true or do not apply:_

- [x] I have performed a self review of my code
- [x] My code follows [Google Java Code style](https://google.github.io/styleguide/javaguide.html)
- [x] I have made my code as simple as possible
- [x] I have added unit tests and the code coverage has not decreased
- [x] I have updated the documentation in all relevant places
