### PR TITLE
Fix/reminder default scheduling time

### DIFF
--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -20,6 +20,19 @@ SPRING_MAIL_USERNAME="user"
 SPRING_MAIL_PASSWORD="pass"
 ```
 
+### Email template
+Templates ensure consistent and automated communications for various functions. 
+We are using [Thymeleaf](https://www.thymeleaf.org/) as the template engine, the email templates are stored in the `resources/templates/` directory.
+
+### Email reminder
+Automates the sending of emails based on schedules. The email reminder service is implemented using [Spring's Task Execution and Scheduling](https://spring.io/guides/gs/scheduling-tasks/). 
+The reminder service is configured in the `application-prod.yml` file.
+```yaml
+reminder:
+  trigger-duration-days: "P7D"
+  cron-schedule-expression: "0 0 0 * * TUE"
+```
+
 ## Development
 
 For development, we advise to use a service called [Mailhog](https://github.com/mailhog/MailHog).

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -43,4 +43,4 @@ logging:
     eu.bbmri_eric.negotiator: info
 reminder:
   trigger-duration-days: "P7D"
-  cron-schedule-expression: "0 0 0 * * MON-FRI"
+  cron-schedule-expression: "0 0 0 * * TUE"


### PR DESCRIPTION
## Negotiator pull request:

### Description:

Changes the default schedule of the reminder emails from every night to Monday midnight

### Checklist:

_Make sure you tick all the boxes bellow if they are true or do not apply:_

- [x] I have performed a self review of my code
- [x] My code follows [Google Java Code style](https://google.github.io/styleguide/javaguide.html)
- [x] I have made my code as simple as possible
- [x] I have added unit tests and the code coverage has not decreased
- [x] I have updated the documentation in all relevant places
