### PR TITLE
feat: adds hal links for negotiation

### DIFF
--- a/src/main/java/eu/bbmri_eric/negotiator/api/controller/v3/NegotiationController.java
+++ b/src/main/java/eu/bbmri_eric/negotiator/api/controller/v3/NegotiationController.java
@@ -215,10 +215,10 @@ public class NegotiationController {
    * @return NegotiationDTO or 403
    */
   @GetMapping("/negotiations/{id}")
-  public NegotiationDTO retrieve(@Valid @PathVariable String id) {
+  public EntityModel<NegotiationDTO> retrieve(@Valid @PathVariable String id) {
     NegotiationDTO negotiationDTO = negotiationService.findById(id, true);
     if (isAuthorizedForNegotiation(negotiationDTO)) {
-      return negotiationDTO;
+      return assembler.toModel(negotiationDTO);
     } else {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN);
     }

--- a/src/main/java/eu/bbmri_eric/negotiator/mappers/NegotiationModelAssembler.java
+++ b/src/main/java/eu/bbmri_eric/negotiator/mappers/NegotiationModelAssembler.java
@@ -3,6 +3,7 @@ package eu.bbmri_eric.negotiator.mappers;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
+import eu.bbmri_eric.negotiator.api.controller.v3.AttachmentController;
 import eu.bbmri_eric.negotiator.api.controller.v3.NegotiationController;
 import eu.bbmri_eric.negotiator.api.controller.v3.NetworkController;
 import eu.bbmri_eric.negotiator.api.controller.v3.utils.NegotiationSortField;
@@ -28,10 +29,17 @@ public class NegotiationModelAssembler
   @Override
   public @NonNull EntityModel<NegotiationDTO> toModel(@NonNull NegotiationDTO entity) {
     List<Link> links = new ArrayList<>();
-    links.add(linkTo(NegotiationController.class).slash("negotiations").withRel("negotiations"));
     links.add(
         WebMvcLinkBuilder.linkTo(methodOn(NegotiationController.class).retrieve(entity.getId()))
             .withSelfRel());
+    links.add(
+        WebMvcLinkBuilder.linkTo(NegotiationController.class)
+            .slash("negotiations/%s/posts".formatted(entity.getId()))
+            .withRel("posts"));
+    links.add(
+        WebMvcLinkBuilder.linkTo(
+                methodOn(AttachmentController.class).listByNegotiation(entity.getId()))
+            .withRel("attachments"));
     return EntityModel.of(entity, links);
   }
 

--- a/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/NegotiationControllerTests.java
+++ b/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/NegotiationControllerTests.java
@@ -66,6 +66,10 @@ public class NegotiationControllerTests {
   private static final String NEGOTIATION_5_ID = "negotiation-5";
   private static final String NEGOTIATION_1_CREATION_DATE = "2024-10-12T00:00:00";
   private static final String NEGOTIATIONS_URL = "/v3/negotiations";
+  private static final String SELF_LINK_TPL = "http://localhost/v3/negotiations/%s";
+  private static final String POSTS_LINK_TPL = "http://localhost/v3/negotiations/%s/posts";
+  private static final String ATTACHMENTS_LINK_TPL =
+      "http://localhost/v3/negotiations/%s/attachments";
 
   @Autowired private WebApplicationContext context;
   @Autowired private NegotiationRepository negotiationRepository;
@@ -739,6 +743,7 @@ public class NegotiationControllerTests {
   @Test
   @WithUserDetails("SarahRepr")
   public void testGetAllForUserBothAuthorAndBiobanker_whenNoFilters() throws Exception {
+
     mockMvc
         .perform(
             MockMvcRequestBuilders.get(
@@ -750,6 +755,18 @@ public class NegotiationControllerTests {
         .andExpect(jsonPath("$.page.totalElements", is(4)))
         .andExpect(jsonPath("$._embedded.negotiations.length()", is(4)))
         .andExpect(jsonPath("$._embedded.negotiations.[0].id", is(NEGOTIATION_5_ID)))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.self.href",
+                is(SELF_LINK_TPL.formatted(NEGOTIATION_5_ID))))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.posts.href",
+                is(POSTS_LINK_TPL.formatted(NEGOTIATION_5_ID))))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.attachments.href",
+                is(ATTACHMENTS_LINK_TPL.formatted(NEGOTIATION_5_ID))))
         .andExpect(jsonPath("$._embedded.negotiations.[1].id", is(NEGOTIATION_3_ID)))
         .andExpect(jsonPath("$._embedded.negotiations.[2].id", is(NEGOTIATION_4_ID)))
         .andExpect(jsonPath("$._embedded.negotiations.[3].id", is(NEGOTIATION_V2_ID)))
@@ -774,6 +791,18 @@ public class NegotiationControllerTests {
         .andExpect(jsonPath("$.page.totalElements", is(2)))
         .andExpect(jsonPath("$._embedded.negotiations.length()", is(2)))
         .andExpect(jsonPath("$._embedded.negotiations.[0].id", is(NEGOTIATION_3_ID)))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.self.href",
+                is(SELF_LINK_TPL.formatted(NEGOTIATION_3_ID))))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.posts.href",
+                is(POSTS_LINK_TPL.formatted(NEGOTIATION_3_ID))))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.attachments.href",
+                is(ATTACHMENTS_LINK_TPL.formatted(NEGOTIATION_3_ID))))
         .andExpect(jsonPath("$._embedded.negotiations.[1].id", is(NEGOTIATION_4_ID)));
   }
 
@@ -797,6 +826,18 @@ public class NegotiationControllerTests {
         .andExpect(jsonPath("$.page.totalElements", is(3)))
         .andExpect(jsonPath("$._embedded.negotiations.length()", is(3)))
         .andExpect(jsonPath("$._embedded.negotiations.[0].id", is(NEGOTIATION_5_ID)))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.self.href",
+                is(SELF_LINK_TPL.formatted(NEGOTIATION_5_ID))))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.posts.href",
+                is(POSTS_LINK_TPL.formatted(NEGOTIATION_5_ID))))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.attachments.href",
+                is(ATTACHMENTS_LINK_TPL.formatted(NEGOTIATION_5_ID))))
         .andExpect(jsonPath("$._embedded.negotiations.[1].id", is(NEGOTIATION_4_ID)))
         .andExpect(jsonPath("$._embedded.negotiations.[2].id", is(NEGOTIATION_V2_ID)));
   }
@@ -816,7 +857,19 @@ public class NegotiationControllerTests {
         .andExpect(content().contentType("application/hal+json"))
         .andExpect(jsonPath("$.page.totalElements", is(1)))
         .andExpect(jsonPath("$._embedded.negotiations.length()", is(1)))
-        .andExpect(jsonPath("$._embedded.negotiations.[0].id", is(NEGOTIATION_4_ID)));
+        .andExpect(jsonPath("$._embedded.negotiations.[0].id", is(NEGOTIATION_4_ID)))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.self.href",
+                is(SELF_LINK_TPL.formatted(NEGOTIATION_4_ID))))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.posts.href",
+                is(POSTS_LINK_TPL.formatted(NEGOTIATION_4_ID))))
+        .andExpect(
+            jsonPath(
+                "$._embedded.negotiations.[0]._links.attachments.href",
+                is(ATTACHMENTS_LINK_TPL.formatted(NEGOTIATION_4_ID))));
   }
 
   @Test
@@ -852,12 +905,20 @@ public class NegotiationControllerTests {
   @Test
   @WithUserDetails("TheResearcher")
   public void testGetById_Ok_whenCorrectId() throws Exception {
+    String selfLink = "http://localhost/v3/negotiations/%s".formatted(NEGOTIATION_1_ID);
+    String postsLink = "http://localhost/v3/negotiations/%s/posts".formatted(NEGOTIATION_1_ID);
+    String attachmentsLink =
+        "http://localhost/v3/negotiations/%s/attachments".formatted(NEGOTIATION_1_ID);
+
     mockMvc
         .perform(MockMvcRequestBuilders.get("%s/%s".formatted(NEGOTIATIONS_URL, NEGOTIATION_1_ID)))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentType("application/hal+json"))
         .andExpect(jsonPath("$.id", is(NEGOTIATION_1_ID)))
-        .andExpect(jsonPath("$.creationDate", is(NEGOTIATION_1_CREATION_DATE)));
+        .andExpect(jsonPath("$.creationDate", is(NEGOTIATION_1_CREATION_DATE)))
+        .andExpect(jsonPath("$._links.self.href", is(selfLink)))
+        .andExpect(jsonPath("$._links.posts.href", is(postsLink)))
+        .andExpect(jsonPath("$._links.attachments.href", is(attachmentsLink)));
   }
 
   @Test

--- a/src/test/java/eu/bbmri_eric/negotiator/unit/mappers/NegotiationModelAssemblerTest.java
+++ b/src/test/java/eu/bbmri_eric/negotiator/unit/mappers/NegotiationModelAssemblerTest.java
@@ -31,12 +31,26 @@ public class NegotiationModelAssemblerTest {
             .getContent()
             .getId());
     assertEquals(
-        "/v3/negotiations",
+        "/v3/negotiations/1/posts",
         negotiationModelAssembler
-            .toModel(new NegotiationDTO())
-            .getLink("negotiations")
+            .toModel(NegotiationDTO.builder().id("1").build())
+            .getLink("posts")
             .get()
             .getHref());
+    assertEquals(
+        "/v3/negotiations/1/attachments",
+        negotiationModelAssembler
+            .toModel(NegotiationDTO.builder().id("1").build())
+            .getLink("attachments")
+            .get()
+            .getHref());
+    //    assertEquals(
+    //        "/v3/negotiations",
+    //        negotiationModelAssembler
+    //            .toModel(new NegotiationDTO())
+    //            .getLink("negotiations")
+    //            .get()
+    //            .getHref());
   }
 
   @Test


### PR DESCRIPTION
## Negotiator pull request:

### Description:

This PR adds the HAL links for negotiation object. In particular it adds links for posts and attachments.
The resulting json is 
```json
{
...
  "_links": {
          "self": {
              "href": "http://localhost:8081/api/v3/negotiations/1"
          },
          "posts": {
              "href": "http://localhost:8081/api/v3/negotiations/1/posts"
          },
          "attachments": {
              "href": "http://localhost:8081/api/v3/negotiations/1/attachments"
          }
      }
}
```

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
