### PR TITLE
feat: Removes unique name constraint from Network and adds a related …

### DIFF
--- a/src/main/java/eu/bbmri_eric/negotiator/governance/network/Network.java
+++ b/src/main/java/eu/bbmri_eric/negotiator/governance/network/Network.java
@@ -47,8 +47,7 @@ public class Network {
   @NotNull private String uri;
 
   /** The name of the network */
-  @Column(unique = true)
-  private String name;
+  @Column private String name;
 
   /** A unique and persistent identifier issued by an appropriate institution */
   @NotNull

--- a/src/main/resources/db/migration/V18.0__drop_uc_network_name_constraint.sql
+++ b/src/main/resources/db/migration/V18.0__drop_uc_network_name_constraint.sql
@@ -1,0 +1,1 @@
+alter table network drop constraint uc_network_name;


### PR DESCRIPTION
## Negotiator pull request:

### Description:

This PR removes the unique constraint in Network's name. As in the Directory this constraint does not exist, this constraint causes issues during the synchronization of the Network entity. 
### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
