### PR TITLE
feat: move REPRESENTATIVE_UNREACHABLE to not Represented Organization…

### DIFF
--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -419,13 +419,17 @@ const organizationsById = computed(() => {
 
 const representedOrganizationsById = computed(() => {
   return Object.entries(organizationsById.value)
-    .filter(([, value]) => value.updatable === true)
+    .filter(
+      ([, value]) => value.updatable === true && value.status !== 'REPRESENTATIVE_UNREACHABLE',
+    )
     .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
 })
 
 const notRepresentedOrganizationsById = computed(() => {
   return Object.entries(organizationsById.value)
-    .filter(([, value]) => value.updatable === false)
+    .filter(
+      ([, value]) => value.updatable === false || value.status === 'REPRESENTATIVE_UNREACHABLE',
+    )
     .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
 })
 


### PR DESCRIPTION
Brief description.
hey Cecilia, so the horizontal line divides those that you represent

Those at the top are yours so to speak

or rather thats how it should work

but now I'm seeing that there could be a bug in this display

yes the ones that are unreachable are displayed at the top as well which should not happen, thanks for flagging this

Desired functionality acceptance criteria
move organization with status REPRESENTATIVE_UNREACHABLE to notRepresentedOrganizationsById
