### PR TITLE
fix: bug when all representatives are getting reminder notification

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/notification/representative/RepresentativeNotificationServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/notification/representative/RepresentativeNotificationServiceImpl.java
@@ -61,7 +61,7 @@ public class RepresentativeNotificationServiceImpl implements RepresentativeNoti
               .filter(resource -> resource.getOrganization().equals(organization))
               .collect(Collectors.toSet());
       Set<Person> representatives =
-          negotiation.getResources().stream()
+          involvedResourcesOfOrganization.stream()
               .flatMap(resource -> resource.getRepresentatives().stream())
               .collect(Collectors.toSet());
       if (!hasOrganizationResponded(


### PR DESCRIPTION
## Negotiator pull request:

### Description:

There is a bug in the Notification scheduling system when all representatives even the ones that have responded will get a notification. This PR provides a fix.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
