### PR TITLE
Fix file upload type validation

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -385,5 +385,10 @@
             <artifactId>commons-csv</artifactId>
             <version>1.13.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>2.9.3</version>
+        </dependency>
     </dependencies>
 </project>

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/AttachmentController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/AttachmentController.java
@@ -2,6 +2,8 @@ package eu.bbmri_eric.negotiator.attachment;
 
 import eu.bbmri_eric.negotiator.attachment.dto.AttachmentDTO;
 import eu.bbmri_eric.negotiator.attachment.dto.AttachmentMetadataDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -46,11 +48,18 @@ public class AttachmentController {
       value = "/negotiations/{negotiationId}/attachments",
       consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(summary = "Upload an attachment to a specific Negotiation")
   @ResponseStatus(HttpStatus.CREATED)
   public AttachmentMetadataDTO createForNegotiation(
-      @PathVariable String negotiationId,
-      @RequestParam("file") @Valid MultipartFile file,
-      @Nullable @RequestParam("organizationId") String organizationId) {
+      @PathVariable @Schema(example = "negotiation-1") String negotiationId,
+      @RequestParam("file") @Valid @Schema(description = "File to be uploaded") MultipartFile file,
+      @Nullable
+          @RequestParam("organizationId")
+          @Schema(
+              example = "biobank:1",
+              description = "External ID of the Organization the attachment is for")
+          String organizationId) {
+    fileTypeValidator.validateObject(file);
     return storageService.createForNegotiation(negotiationId, organizationId, file);
   }
 
@@ -75,8 +84,13 @@ public class AttachmentController {
       value = "/attachments",
       consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(
+      summary = "Post an attachment",
+      description = "Upload an attachment that you can then reference in a Negotiation")
   @ResponseStatus(HttpStatus.CREATED)
-  public AttachmentMetadataDTO create(@RequestParam("file") @Valid MultipartFile file) {
+  public AttachmentMetadataDTO create(
+      @RequestParam("file") @Valid @Schema(description = "File to be uploaded")
+          MultipartFile file) {
     fileTypeValidator.validateObject(file);
     return storageService.create(file);
   }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/FileTypeValidator.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/FileTypeValidator.java
@@ -1,0 +1,53 @@
+package eu.bbmri_eric.negotiator.attachment;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import org.apache.tika.Tika;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class FileTypeValidator implements Validator {
+
+  private static final Tika tika = new Tika();
+  private static final List<String> ALLOWED_MIME_TYPES =
+      List.of(
+          "application/pdf",
+          "image/png",
+          "image/jpeg",
+          "application/msword", // .doc
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
+          "text/plain", // .txt
+          "text/csv", // .csv
+          "application/vnd.ms-excel", // .xls (Excel 97-2003)
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" // .xlsx
+          );
+
+  @Override
+  public boolean supports(Class<?> clazz) {
+    return MultipartFile.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  public void validate(Object target, Errors errors) {
+    MultipartFile file = (MultipartFile) target;
+    if (file.isEmpty()) {
+      throw new IllegalArgumentException("File cannot be empty");
+    }
+
+    try (InputStream inputStream = file.getInputStream()) {
+      String detectedType = tika.detect(inputStream);
+      if (!ALLOWED_MIME_TYPES.contains(detectedType)) {
+        throw new UnsupportedFileTypeException(
+            "File type "
+                + detectedType
+                + " is not supported. Try more conventional file formats such as PDF, JPEG or CSV");
+      }
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Could not read file: " + file.getOriginalFilename());
+    }
+  }
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/FileTypeValidator.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/FileTypeValidator.java
@@ -3,13 +3,16 @@ package eu.bbmri_eric.negotiator.attachment;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import lombok.extern.apachecommons.CommonsLog;
 import org.apache.tika.Tika;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.springframework.web.multipart.MultipartFile;
 
+/** Validates File type based on decoded mime type. */
 @Component
+@CommonsLog
 public class FileTypeValidator implements Validator {
 
   private static final Tika tika = new Tika();
@@ -40,6 +43,7 @@ public class FileTypeValidator implements Validator {
 
     try (InputStream inputStream = file.getInputStream()) {
       String detectedType = tika.detect(inputStream);
+      log.debug("Detected attachment type: " + detectedType);
       if (!ALLOWED_MIME_TYPES.contains(detectedType)) {
         throw new UnsupportedFileTypeException(
             "File type "

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/FileTypeValidator.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/FileTypeValidator.java
@@ -10,12 +10,13 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.springframework.web.multipart.MultipartFile;
 
-/** Validates File type based on decoded mime type. */
+/** Validates file type based on decoded MIME type and file extension. */
 @Component
 @CommonsLog
 public class FileTypeValidator implements Validator {
 
   private static final Tika tika = new Tika();
+
   private static final List<String> ALLOWED_MIME_TYPES =
       List.of(
           "application/pdf",
@@ -29,6 +30,9 @@ public class FileTypeValidator implements Validator {
           "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" // .xlsx
           );
 
+  private static final List<String> ALLOWED_EXTENSIONS =
+      List.of("pdf", "png", "jpeg", "jpg", "doc", "docx", "txt", "csv", "xls", "xlsx");
+
   @Override
   public boolean supports(Class<?> clazz) {
     return MultipartFile.class.isAssignableFrom(clazz);
@@ -40,18 +44,60 @@ public class FileTypeValidator implements Validator {
     if (file.isEmpty()) {
       throw new IllegalArgumentException("File cannot be empty");
     }
+    String originalFilename = file.getOriginalFilename();
+    validateFileExtension(originalFilename);
 
     try (InputStream inputStream = file.getInputStream()) {
-      String detectedType = tika.detect(inputStream);
-      log.debug("Detected attachment type: " + detectedType);
-      if (!ALLOWED_MIME_TYPES.contains(detectedType)) {
-        throw new UnsupportedFileTypeException(
-            "File type "
-                + detectedType
-                + " is not supported. Try more conventional file formats such as PDF, JPEG or CSV");
-      }
+      validateMimeType(inputStream);
     } catch (IOException e) {
-      throw new IllegalArgumentException("Could not read file: " + file.getOriginalFilename());
+      throw new IllegalArgumentException("Could not read file: " + originalFilename, e);
     }
+  }
+
+  /**
+   * Validates the file extension against a whitelist.
+   *
+   * @param originalFilename the original file name
+   */
+  private void validateFileExtension(String originalFilename) {
+    String fileExtension = getFileExtension(originalFilename);
+    log.debug("Detected file extension: " + fileExtension);
+    if (!ALLOWED_EXTENSIONS.contains(fileExtension)) {
+      throw new UnsupportedFileTypeException(
+          "File extension '"
+              + fileExtension
+              + "' is not supported. Allowed extensions are: "
+              + ALLOWED_EXTENSIONS);
+    }
+  }
+
+  /**
+   * Validates the MIME type by analyzing the file's input stream.
+   *
+   * @param inputStream the input stream of the file
+   * @throws IOException if an I/O error occurs reading the stream
+   */
+  private void validateMimeType(InputStream inputStream) throws IOException {
+    String detectedType = tika.detect(inputStream);
+    log.debug("Detected MIME type: " + detectedType);
+    if (!ALLOWED_MIME_TYPES.contains(detectedType)) {
+      throw new UnsupportedFileTypeException(
+          "File type '"
+              + detectedType
+              + "' is not supported. Try more conventional file formats such as PDF, JPEG or CSV");
+    }
+  }
+
+  /**
+   * Extracts the file extension from the given file name.
+   *
+   * @param fileName the original file name
+   * @return the file extension in lower case, or an empty string if none is found
+   */
+  private String getFileExtension(String fileName) {
+    if (fileName == null || !fileName.contains(".")) {
+      return "";
+    }
+    return fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase();
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/UnsupportedFileTypeException.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/UnsupportedFileTypeException.java
@@ -1,0 +1,7 @@
+package eu.bbmri_eric.negotiator.attachment;
+
+public class UnsupportedFileTypeException extends RuntimeException {
+  public UnsupportedFileTypeException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
@@ -1,5 +1,6 @@
 package eu.bbmri_eric.negotiator.common.exceptions;
 
+import eu.bbmri_eric.negotiator.attachment.UnsupportedFileTypeException;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -209,6 +210,7 @@ public class NegotiatorExceptionHandler {
     EntityNotStorableException.class,
     WrongRequestException.class,
     ConstraintViolationException.class,
+    UnsupportedFileTypeException.class,
   })
   @ApiResponse(
       responseCode = "400",

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/AttachmentControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/AttachmentControllerTests.java
@@ -1,5 +1,6 @@
 package eu.bbmri_eric.negotiator.integration.api.v3;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.anonymous;
@@ -237,5 +238,29 @@ public class AttachmentControllerTests {
             get(String.format("%s", WITH_NEGOTIATIONS_ENDPOINT))
                 .with(httpBasic("researcher", "wrong_pass")))
         .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithUserDetails("TheResearcher")
+  @Transactional
+  public void test_CreateWithExeFile_ShouldReject() throws Exception {
+    byte[] data = new byte[] {0x4D, 0x5A, (byte) 0x90, 0x00};
+    String fileName = "malicious_file.exe";
+    MockMultipartFile file =
+        new MockMultipartFile("file", fileName, MediaType.APPLICATION_OCTET_STREAM_VALUE, data);
+    mockMvc
+        .perform(multipart(WITHOUT_NEGOTIATIONS_ENDPOINT).file(file))
+        .andDo(print())
+        .andExpect(status().isBadRequest()) // Expecting bad request if validation fails
+        .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(jsonPath("$.detail", containsString("not supported")));
+    fileName = "malicious_file.exe.pdf";
+    file = new MockMultipartFile("file", fileName, MediaType.APPLICATION_OCTET_STREAM_VALUE, data);
+    mockMvc
+        .perform(multipart(WITHOUT_NEGOTIATIONS_ENDPOINT).file(file))
+        .andDo(print())
+        .andExpect(status().isBadRequest()) // Expecting bad request if validation fails
+        .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(jsonPath("$.detail", containsString("not supported")));
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/AttachmentControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/AttachmentControllerTests.java
@@ -257,7 +257,7 @@ public class AttachmentControllerTests {
     fileName = "malicious_file.exe.pdf";
     file = new MockMultipartFile("file", fileName, MediaType.APPLICATION_OCTET_STREAM_VALUE, data);
     mockMvc
-        .perform(multipart(WITHOUT_NEGOTIATIONS_ENDPOINT).file(file))
+        .perform(multipart(WITH_NEGOTIATIONS_ENDPOINT).file(file))
         .andDo(print())
         .andExpect(status().isBadRequest()) // Expecting bad request if validation fails
         .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))

--- a/frontend/src/components/NegotiationForm.vue
+++ b/frontend/src/components/NegotiationForm.vue
@@ -210,7 +210,7 @@
               Uploaded file: {{ negotiationCriteria[section.name][criteria.name].name }}
             </label>
             <input
-              accept=".pdf, .png, .jpeg, .jpg, .doc, .docx, .txt, .csv, .xls, .xlsx, application/pdf, image/png, image/jpeg, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, text/plain, text/csv, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+              :accept="fileExtensions"
               class="form-control text-secondary-text"
               :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
               :required="criteria.required"
@@ -377,6 +377,8 @@ import { useNotificationsStore } from '../store/notifications'
 import { useUiConfiguration } from '@/store/uiConfiguration.js'
 import { useNegotiationPageStore } from '../store/negotiationPage.js'
 import 'vue3-form-wizard/dist/style.css'
+import fileExtensions from '@/config/uploadFileExtensions.js'
+
 
 const uiConfigurationStore = useUiConfiguration()
 const negotiationFormStore = useNegotiationFormStore()

--- a/frontend/src/components/NegotiationForm.vue
+++ b/frontend/src/components/NegotiationForm.vue
@@ -210,7 +210,7 @@
               Uploaded file: {{ negotiationCriteria[section.name][criteria.name].name }}
             </label>
             <input
-              accept=".pdf, .png, .jpeg, .jpg, .doc, .docx, .txt, .csv, .xls, .xlsx"
+              accept=".pdf, .png, .jpeg, .jpg, .doc, .docx, .txt, .csv, .xls, .xlsx, application/pdf, image/png, image/jpeg, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, text/plain, text/csv, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
               class="form-control text-secondary-text"
               :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
               :required="criteria.required"

--- a/frontend/src/components/NegotiationForm.vue
+++ b/frontend/src/components/NegotiationForm.vue
@@ -210,7 +210,7 @@
               Uploaded file: {{ negotiationCriteria[section.name][criteria.name].name }}
             </label>
             <input
-              accept=".pdf"
+              accept=".pdf, .png, .jpeg, .jpg, .doc, .docx, .txt, .csv, .xls, .xlsx"
               class="form-control text-secondary-text"
               :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
               :required="criteria.required"
@@ -366,7 +366,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onBeforeMount, onMounted, watch } from 'vue'
+import { computed, onBeforeMount, onMounted, ref, watch } from 'vue'
 import { Tooltip } from 'bootstrap'
 import { useRouter } from 'vue-router'
 import ConfirmationModal from '@/components/modals/ConfirmationModal.vue'

--- a/frontend/src/components/NegotiationForm.vue
+++ b/frontend/src/components/NegotiationForm.vue
@@ -210,6 +210,7 @@
               Uploaded file: {{ negotiationCriteria[section.name][criteria.name].name }}
             </label>
             <input
+              :key="fileInputKey"
               :accept="fileExtensions"
               class="form-control text-secondary-text"
               :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
@@ -378,6 +379,7 @@ import { useUiConfiguration } from '@/store/uiConfiguration.js'
 import { useNegotiationPageStore } from '../store/negotiationPage.js'
 import 'vue3-form-wizard/dist/style.css'
 import fileExtensions from '@/config/uploadFileExtensions.js'
+import { isFileExtensionsSuported } from '../composables/utils.js'
 
 
 const uiConfigurationStore = useUiConfiguration()
@@ -570,8 +572,14 @@ function isAttachment(value) {
   return value instanceof File || value instanceof Object
 }
 
+let fileInputKey = ref(0)
+
 function handleFileUpload(event, section, criteria) {
-  negotiationCriteria.value[section][criteria] = event.target.files[0]
+  if(isFileExtensionsSuported(event.target.files[0])) {
+    negotiationCriteria.value[section][criteria] = event.target.files[0]
+  } else {
+    fileInputKey.value++
+  }
 }
 
 function showNotification(header, body) {

--- a/frontend/src/components/NegotiationPosts.vue
+++ b/frontend/src/components/NegotiationPosts.vue
@@ -76,7 +76,9 @@
           :title="
             negotiation.publicPostsEnabled
               ? ''
-              : negotiation.status === 'DRAFT' ? 'Messaging is unavailable until you submit the request' : 'Messaging is unavailable until the request has been reviewed.'
+              : negotiation.status === 'DRAFT'
+                ? 'Messaging is unavailable until you submit the request'
+                : 'Messaging is unavailable until the request has been reviewed.'
           "
         >
           <button
@@ -94,6 +96,7 @@
         </span>
         <button type="submit" class="btn btn-attachment ms-2 border rounded">
           <input
+            :key="fileInputKey"
             id="attachment"
             class="form-control"
             type="file"
@@ -136,6 +139,7 @@ import { useOidcStore } from '../store/oidc'
 import { useNegotiationPageStore } from '../store/negotiationPage.js'
 import { useUiConfiguration } from '@/store/uiConfiguration.js'
 import fileExtensions from '@/config/uploadFileExtensions.js'
+import { isFileExtensionsSuported } from '../composables/utils.js'
 
 const uiConfigurationStore = useUiConfiguration()
 
@@ -263,9 +267,16 @@ function printDate(date) {
   return moment(date).format(dateFormat)
 }
 
+let fileInputKey = ref(0)
+
 function showAttachment(event) {
   const file = event.target.files[0]
-  attachment.value = file
+
+  if (isFileExtensionsSuported(file)) {
+    attachment.value = file
+  } else {
+    fileInputKey.value++
+  }
 }
 
 async function sendMessage() {
@@ -348,9 +359,9 @@ defineExpose({
 </script>
 
 <style scoped>
-.btn-attachment  {
-    position: relative;
-    overflow: hidden;
+.btn-attachment {
+  position: relative;
+  overflow: hidden;
 }
 /** the input file is hidden */
 .btn-attachment input[type='file'] {

--- a/frontend/src/components/NegotiationPosts.vue
+++ b/frontend/src/components/NegotiationPosts.vue
@@ -97,7 +97,7 @@
             id="attachment"
             class="form-control"
             type="file"
-            accept=".pdf, .png, .jpeg, .jpg, .doc, .docx, .txt, .csv, .xls, .xlsx, application/pdf, image/png, image/jpeg, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, text/plain, text/csv, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            :accept="fileExtensions"
             @change="showAttachment"
           />
           <i class="bi bi-paperclip" />
@@ -135,6 +135,7 @@ import NegotiationAttachment from './NegotiationAttachment.vue'
 import { useOidcStore } from '../store/oidc'
 import { useNegotiationPageStore } from '../store/negotiationPage.js'
 import { useUiConfiguration } from '@/store/uiConfiguration.js'
+import fileExtensions from '@/config/uploadFileExtensions.js'
 
 const uiConfigurationStore = useUiConfiguration()
 

--- a/frontend/src/components/NegotiationPosts.vue
+++ b/frontend/src/components/NegotiationPosts.vue
@@ -97,7 +97,7 @@
             id="attachment"
             class="form-control"
             type="file"
-            accept="application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            accept=".pdf, .png, .jpeg, .jpg, .doc, .docx, .txt, .csv, .xls, .xlsx, application/pdf, image/png, image/jpeg, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, text/plain, text/csv, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
             @change="showAttachment"
           />
           <i class="bi bi-paperclip" />

--- a/frontend/src/components/modals/FormSubmissionModal.vue
+++ b/frontend/src/components/modals/FormSubmissionModal.vue
@@ -181,7 +181,7 @@
 
                 <div v-else-if="criteria.type === 'FILE'">
                   <input
-                    accept=".pdf"
+                    accept=".pdf, .png, .jpeg, .jpg, .doc, .docx, .txt, .csv, .xls, .xlsx"
                     class="form-control text-secondary-text"
                     :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
                     :required="criteria.required"

--- a/frontend/src/components/modals/FormSubmissionModal.vue
+++ b/frontend/src/components/modals/FormSubmissionModal.vue
@@ -181,6 +181,7 @@
 
                 <div v-else-if="criteria.type === 'FILE'">
                   <input
+                    :key="fileInputKey"
                     :accept="fileExtensions"
                     class="form-control text-secondary-text"
                     :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
@@ -309,6 +310,7 @@ import 'vue3-form-wizard/dist/style.css'
 import { useFormsStore } from '../../store/forms'
 import { useNotificationsStore } from '../../store/notifications'
 import fileExtensions from '@/config/uploadFileExtensions.js'
+import { isFileExtensionsSuported } from '../../composables/utils.js'
 
 const props = defineProps({
   id: {
@@ -415,8 +417,14 @@ function isAttachment(value) {
   return value instanceof File || value instanceof Object
 }
 
+let fileInputKey = ref(0)
+
 function handleFileUpload(event, section, criteria) {
-  negotiationCriteria.value[section][criteria] = event.target.files[0]
+  if (isFileExtensionsSuported(event.target.files[0])) {
+    negotiationCriteria.value[section][criteria] = event.target.files[0]
+  } else {
+    fileInputKey.value++
+  }
 }
 
 function showNotification(header, body) {

--- a/frontend/src/components/modals/FormSubmissionModal.vue
+++ b/frontend/src/components/modals/FormSubmissionModal.vue
@@ -181,7 +181,7 @@
 
                 <div v-else-if="criteria.type === 'FILE'">
                   <input
-                    accept=".pdf, .png, .jpeg, .jpg, .doc, .docx, .txt, .csv, .xls, .xlsx"
+                    accept=".pdf, .png, .jpeg, .jpg, .doc, .docx, .txt, .csv, .xls, .xlsx, application/pdf, image/png, image/jpeg, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, text/plain, text/csv, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
                     class="form-control text-secondary-text"
                     :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
                     :required="criteria.required"

--- a/frontend/src/components/modals/FormSubmissionModal.vue
+++ b/frontend/src/components/modals/FormSubmissionModal.vue
@@ -181,7 +181,7 @@
 
                 <div v-else-if="criteria.type === 'FILE'">
                   <input
-                    accept=".pdf, .png, .jpeg, .jpg, .doc, .docx, .txt, .csv, .xls, .xlsx, application/pdf, image/png, image/jpeg, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, text/plain, text/csv, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                    :accept="fileExtensions"
                     class="form-control text-secondary-text"
                     :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
                     :required="criteria.required"
@@ -308,6 +308,7 @@ import { FormWizard, TabContent } from 'vue3-form-wizard'
 import 'vue3-form-wizard/dist/style.css'
 import { useFormsStore } from '../../store/forms'
 import { useNotificationsStore } from '../../store/notifications'
+import fileExtensions from '@/config/uploadFileExtensions.js'
 
 const props = defineProps({
   id: {

--- a/frontend/src/composables/utils.js
+++ b/frontend/src/composables/utils.js
@@ -183,3 +183,19 @@ export function generatePieChartBackgroundColorArray(labelsArray) {
 
   return pieChartBackgroundColorArray
 }
+
+import fileExtensions from '@/config/uploadFileExtensions.js'
+import { useNotificationsStore } from '../store/notifications'
+
+export function isFileExtensionsSuported(file) {
+  const notificationsStore = useNotificationsStore()
+
+  if (fileExtensions.includes(file['type'])) {
+    return true
+  }
+  notificationsStore.setNotification(
+    'Invalid file type. Please upload a file with a valid extension.',
+    'danger',
+  )
+  return false
+}

--- a/frontend/src/config/uploadFileExtensions.js
+++ b/frontend/src/config/uploadFileExtensions.js
@@ -1,0 +1,3 @@
+const fileExtensions = ".pdf, .png, .jpeg, .jpg, .doc, .docx, .txt, .csv, .xls, .xlsx, application/pdf, image/png, image/jpeg, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, text/plain, text/csv, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+export default fileExtensions


### PR DESCRIPTION
## Negotiator pull request:

### Description:

This PR adds File type validation on the API level. To test it spin up the backend and try to upload as many different attachment types as possible. http://localhost:8081/api/swagger-ui/index.html#/Attachments/create_1

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
