### PR TITLE
fix: payload ordering for Negotiation and InformationSubmission

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
@@ -117,6 +117,24 @@ public class NegotiatorExceptionHandler {
     EntityNotFoundException.class,
     jakarta.persistence.EntityNotFoundException.class
   })
+  @ApiResponse(
+      responseCode = "404",
+      description = "Not Found - The requested resource does not exist",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ProblemDetail.class),
+              examples =
+                  @ExampleObject(
+                      value =
+                          """
+                                  {
+                                    "status": 404,
+                                    "title": "Resource Not Found",
+                                    "type": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404",
+                                    "detail": "The resource you are looking for does not exist or could not be found."
+                                  }
+                                  """)))
   public final ResponseEntity<HttpErrorResponseModel> handleEntityNotFoundException(
       EntityNotFoundException ex, WebRequest request) {
     HttpErrorResponseModel errorResponse =

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/info_submission/InformationSubmission.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/info_submission/InformationSubmission.java
@@ -3,6 +3,8 @@ package eu.bbmri_eric.negotiator.info_submission;
 import eu.bbmri_eric.negotiator.governance.resource.Resource;
 import eu.bbmri_eric.negotiator.info_requirement.InformationRequirement;
 import eu.bbmri_eric.negotiator.negotiation.Negotiation;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -11,8 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
+import org.hibernate.annotations.Type;
 
 /** Represents a submission of additional information by the resource representative. */
 @Setter
@@ -62,6 +63,7 @@ public class InformationSubmission {
   @JoinColumn(name = "negotiation_id")
   private Negotiation negotiation;
 
-  @JdbcTypeCode(SqlTypes.JSON)
+  @Type(JsonType.class)
+  @Column(columnDefinition = "json")
   private String payload;
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/Negotiation.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/Negotiation.java
@@ -37,9 +37,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.Formula;
-import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
 import org.hibernate.annotations.UuidGenerator;
-import org.hibernate.type.SqlTypes;
 
 /** A Core Entity representing a Negotiation between multiple parties about access to resources. */
 @Entity
@@ -84,10 +83,11 @@ public class Negotiation extends AuditEntity {
   @Setter(AccessLevel.PRIVATE)
   private Set<NegotiationResourceLink> resourcesLink = new HashSet<>();
 
-  @Formula(value = "JSONB_EXTRACT_PATH_TEXT(payload, 'project', 'title')")
+  @Formula(value = "JSON_EXTRACT_PATH_TEXT(payload, 'project', 'title')")
   private String title;
 
-  @JdbcTypeCode(SqlTypes.JSON)
+  @Type(JsonType.class)
+  @Column(columnDefinition = "json")
   private String payload;
 
   private boolean publicPostsEnabled;

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/Negotiation.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/Negotiation.java
@@ -36,6 +36,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.UuidGenerator;
@@ -88,6 +89,7 @@ public class Negotiation extends AuditEntity {
 
   @Type(JsonType.class)
   @Column(columnDefinition = "json")
+  @ColumnTransformer(read = "payload::text", write = "?::json")
   private String payload;
 
   private boolean publicPostsEnabled;

--- a/backend/src/main/resources/db/migration/V24.0__fix_payload_order.sql
+++ b/backend/src/main/resources/db/migration/V24.0__fix_payload_order.sql
@@ -1,0 +1,4 @@
+ALTER TABLE negotiation
+    alter column payload set data type json;
+ALTER TABLE information_submission
+    alter column payload set data type json;

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/NegotiationControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/NegotiationControllerTests.java
@@ -1041,7 +1041,6 @@ public class NegotiationControllerTests {
     MvcResult result2 =
         mockMvc
             .perform(MockMvcRequestBuilders.get(NEGOTIATIONS_URL + "/" + negotiationId))
-            .andDo(print())
             .andExpect(status().isOk())
             .andReturn();
     actualPayloadObject = JsonPath.read(result2.getResponse().getContentAsString(), "$.payload");
@@ -1089,7 +1088,6 @@ public class NegotiationControllerTests {
             MockMvcRequestBuilders.put("/v3/negotiations/negotiation-1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.jsonFromRequest(updateDTO)))
-        .andDo(print())
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").isString())

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/NegotiationControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/NegotiationControllerTests.java
@@ -134,6 +134,7 @@ public class NegotiationControllerTests {
    */
   @Test
   @WithUserDetails("admin")
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
   public void testGetAllForAdministrator_whenNoFilters() throws Exception {
     mockMvc
         .perform(MockMvcRequestBuilders.get("/v3/negotiations"))
@@ -991,6 +992,7 @@ public class NegotiationControllerTests {
   @Test
   @WithUserDetails("researcher") // researcher not
   @Transactional
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
   public void testCreate_Ok() throws Exception {
     NegotiationCreateDTO request = TestUtils.createNegotiation(REQUEST_UNASSIGNED, false);
     String requestBody = TestUtils.jsonFromRequest(request);


### PR DESCRIPTION
## Negotiator pull request:

### Description:

This PR fixes the payload ordering problem for Negotiation and Information Submission. JSON is stored exactly as received. To test it create a Negotiation (as draft for example) and verify that the details are shown in the same order as the access form is presented.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
