### PR TITLE
feat: add support for deleting draft negotiation

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/ConflictStatusException.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/ConflictStatusException.java
@@ -1,7 +1,7 @@
 package eu.bbmri_eric.negotiator.common.exceptions;
 
 public class ConflictStatusException extends RuntimeException {
-    public ConflictStatusException(String message) {
-        super(message);
-    }
+  public ConflictStatusException(String message) {
+    super(message);
+  }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/ConflictStatusException.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/ConflictStatusException.java
@@ -1,0 +1,7 @@
+package eu.bbmri_eric.negotiator.common.exceptions;
+
+public class ConflictStatusException extends RuntimeException {
+    public ConflictStatusException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
@@ -460,7 +460,7 @@ public class NegotiatorExceptionHandler {
   @ExceptionHandler(ConflictStatusException.class)
   @ApiResponse(
       responseCode = "409",
-      description = "Conflict: The status of the resource is in conflict with the one required",
+      description = "Conflict: The status of the resource is in conflict with the one requested",
       content =
           @Content(
               mediaType = "application/json+problem",
@@ -472,7 +472,7 @@ public class NegotiatorExceptionHandler {
                                             "type": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409",
                                             "title": "Conflict",
                                             "status": 409,
-                                            "detail": "The status of the resource is in conflict with the one required.",
+                                            "detail": "The status of the resource is in conflict with the one requested.",
                                             "instance": "/api/your-endpoint"
                                           }
                                           """)))

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
@@ -456,6 +456,17 @@ public class NegotiatorExceptionHandler {
     return problemDetail;
   }
 
+  @ResponseStatus(HttpStatus.CONFLICT)
+  @ExceptionHandler(ConflictStatusException.class)
+  public final ProblemDetail handleConflictStatusException( HttpMessageNotReadableException exception) {
+    ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+    problemDetail.setTitle("Conflict");
+    problemDetail.setDetail(exception.getMessage());
+    problemDetail.setType(
+            URI.create("https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409"));
+    return problemDetail;
+  }
+
   private static void extractDetails(
       MethodArgumentNotValidException e, Map<String, String> errors) {
     e.getBindingResult()

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
@@ -458,12 +458,13 @@ public class NegotiatorExceptionHandler {
 
   @ResponseStatus(HttpStatus.CONFLICT)
   @ExceptionHandler(ConflictStatusException.class)
-  public final ProblemDetail handleConflictStatusException( HttpMessageNotReadableException exception) {
+  public final ProblemDetail handleConflictStatusException(
+      HttpMessageNotReadableException exception) {
     ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.CONFLICT);
     problemDetail.setTitle("Conflict");
     problemDetail.setDetail(exception.getMessage());
     problemDetail.setType(
-            URI.create("https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409"));
+        URI.create("https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409"));
     return problemDetail;
   }
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
@@ -458,8 +458,7 @@ public class NegotiatorExceptionHandler {
 
   @ResponseStatus(HttpStatus.CONFLICT)
   @ExceptionHandler(ConflictStatusException.class)
-  public final ProblemDetail handleConflictStatusException(
-      HttpMessageNotReadableException exception) {
+  public final ProblemDetail handleConflictStatusException(ConflictStatusException exception) {
     ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.CONFLICT);
     problemDetail.setTitle("Conflict");
     problemDetail.setDetail(exception.getMessage());

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/exceptions/NegotiatorExceptionHandler.java
@@ -458,6 +458,24 @@ public class NegotiatorExceptionHandler {
 
   @ResponseStatus(HttpStatus.CONFLICT)
   @ExceptionHandler(ConflictStatusException.class)
+  @ApiResponse(
+      responseCode = "409",
+      description = "Conflict: The status of the resource is in conflict with the one required",
+      content =
+          @Content(
+              mediaType = "application/json+problem",
+              examples =
+                  @ExampleObject(
+                      value =
+                          """
+                                          {
+                                            "type": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409",
+                                            "title": "Conflict",
+                                            "status": 409,
+                                            "detail": "The status of the resource is in conflict with the one required.",
+                                            "instance": "/api/your-endpoint"
+                                          }
+                                          """)))
   public final ProblemDetail handleConflictStatusException(ConflictStatusException exception) {
     ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.CONFLICT);
     problemDetail.setTitle("Conflict");

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
@@ -171,6 +171,7 @@ public class NegotiationController {
           "Endpoint to remove a negotiation. The operation is allowed only if the Negotiation is in DRAFT "
               + "state and the user that is deleting it is the creator")
   public void delete(@Valid @PathVariable String id) {
+
     negotiationService.deleteNegotiation(id);
   }
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
@@ -21,6 +21,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.extern.apachecommons.CommonsLog;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
@@ -42,10 +45,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/v3")
@@ -161,20 +160,19 @@ public class NegotiationController {
    * Delete a negotiation
    *
    * @param id of the negotiation
-   * @return 204 No Content in case of success, 404 Not Found in case the negotiation doesn't exist, 403 in case the
-   * operation is Forbidden
+   * @return 204 No Content in case of success, 404 Not Found in case the negotiation doesn't exist,
+   *     403 in case the operation is Forbidden
    */
   @DeleteMapping("/negotiations/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @Operation(
-          summary = "Delete a negotiation",
-          description =
-                  "Endpoint to remove a negotiation. The operation is allowed only if the Negotiation is in DRAFT " +
-                          "state and the user that is deleting it is the creator")
+      summary = "Delete a negotiation",
+      description =
+          "Endpoint to remove a negotiation. The operation is allowed only if the Negotiation is in DRAFT "
+              + "state and the user that is deleting it is the creator")
   public void delete(@Valid @PathVariable String id) {
     negotiationService.deleteNegotiation(id);
   }
-
 
   /**
    * Interact with the state of a negotiation by sending an Event

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationService.java
@@ -151,4 +151,12 @@ public interface NegotiationService {
    */
   Iterable<NegotiationDTO> findAllForNetwork(
       Long networkId, NegotiationFilterDTO negotiationFilterDTO);
+
+  /**
+   * Delete the Negotiation with the specified id. The Negotiation can be deleted only by its creator and only
+   * when it is in DRAFT state
+   *
+   * @param negotiationId the if of the network
+   */
+  void deleteNegotiation(String negotiationId);
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationService.java
@@ -153,8 +153,8 @@ public interface NegotiationService {
       Long networkId, NegotiationFilterDTO negotiationFilterDTO);
 
   /**
-   * Delete the Negotiation with the specified id. The Negotiation can be deleted only by its creator and only
-   * when it is in DRAFT state
+   * Delete the Negotiation with the specified id. The Negotiation can be deleted only by its
+   * creator and only when it is in DRAFT state
    *
    * @param negotiationId the if of the network
    */

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationService.java
@@ -156,7 +156,7 @@ public interface NegotiationService {
    * Delete the Negotiation with the specified id. The Negotiation can be deleted only by its
    * creator and only when it is in DRAFT state
    *
-   * @param negotiationId the if of the network
+   * @param negotiationId the id of the negotiation to delete
    */
   void deleteNegotiation(String negotiationId);
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
@@ -341,10 +341,11 @@ public class NegotiationServiceImpl implements NegotiationService {
   }
 
   public void deleteNegotiation(String negotiationId) {
-    if (!isNegotiationCreator(negotiationId)) {
+    Negotiation negotiation = findEntityById(negotiationId, false);
+    if (!isNegotiationCreator(negotiationId)
+        && !AuthenticatedUserContext.isCurrentlyAuthenticatedUserAdmin()) {
       throw new ForbiddenRequestException("You are not allowed to delete this entity");
     }
-    Negotiation negotiation = findEntityById(negotiationId, false);
     if (negotiation.getCurrentState() != NegotiationState.DRAFT) {
       throw new ConflictStatusException("Cannot delete a Negotiation that is not in DRAFT state");
     }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
@@ -23,6 +23,11 @@ import eu.bbmri_eric.negotiator.user.Person;
 import eu.bbmri_eric.negotiator.user.PersonRepository;
 import eu.bbmri_eric.negotiator.user.PersonService;
 import jakarta.transaction.Transactional;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.apachecommons.CommonsLog;
 import org.hibernate.exception.DataException;
 import org.modelmapper.ModelMapper;
@@ -34,12 +39,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service(value = "DefaultNegotiationService")
 @CommonsLog

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationSpecification.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationSpecification.java
@@ -32,8 +32,6 @@ public class NegotiationSpecification {
         specs = initOrAnd(specs, hasResourcesIn(user.getResources()));
         specs = initOrAnd(specs, hasState(List.of(NegotiationState.DRAFT), true));
       }
-    } else {
-      specs = initOrAnd(specs, hasState(List.of(NegotiationState.DRAFT), true));
     }
 
     if (filtersDTO.getStatus() != null && !filtersDTO.getStatus().isEmpty()) {

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/NegotiationControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/NegotiationControllerTests.java
@@ -31,6 +31,7 @@ import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationUpdateDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.UpdateResourcesDTO;
 import eu.bbmri_eric.negotiator.negotiation.request.RequestRepository;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
 import eu.bbmri_eric.negotiator.post.Post;
 import eu.bbmri_eric.negotiator.post.PostRepository;
@@ -1589,5 +1590,69 @@ public class NegotiationControllerTests {
     mockMvc
         .perform(MockMvcRequestBuilders.get("/v3/negotiations/negotiation-1/posts"))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  public void testDelete_Unauthorized() throws Exception {
+    mockMvc
+        .perform(MockMvcRequestBuilders.delete("%s/negotiation-1".formatted(NEGOTIATIONS_URL)))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithUserDetails("SarahRepr")
+  public void testDelete_Forbidden_whenUserNotCreatorOrAdmin() throws Exception {
+    mockMvc
+        .perform(MockMvcRequestBuilders.delete("%s/negotiation-1".formatted(NEGOTIATIONS_URL)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithUserDetails("TheResearcher")
+  public void testDelete_NotFound() throws Exception {
+    mockMvc
+        .perform(MockMvcRequestBuilders.delete("%s/unknown".formatted(NEGOTIATIONS_URL)))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithUserDetails("TheResearcher")
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+  public void testDelete_conflict_whenWrongStatus() throws Exception {
+    mockMvc
+        .perform(MockMvcRequestBuilders.delete("%s/negotiation-1".formatted(NEGOTIATIONS_URL)))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @WithUserDetails("TheResearcher")
+  @Transactional
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+  public void testDelete_ok_whenNegotiatorAuthor() throws Exception {
+    Negotiation negotiation = negotiationRepository.findById("negotiation-1").get();
+    negotiation.setCurrentState(NegotiationState.DRAFT);
+    negotiationRepository.save(negotiation);
+
+    mockMvc
+        .perform(MockMvcRequestBuilders.delete("%s/negotiation-1".formatted(NEGOTIATIONS_URL)))
+        .andExpect(status().isNoContent());
+
+    assertFalse(negotiationRepository.findById("negotiation-1").isPresent());
+  }
+
+  @Test
+  @WithUserDetails("admin")
+  @Transactional
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+  public void testDelete_ok_whenAdmin() throws Exception {
+    Negotiation negotiation = negotiationRepository.findById("negotiation-1").get();
+    negotiation.setCurrentState(NegotiationState.DRAFT);
+    negotiationRepository.save(negotiation);
+
+    mockMvc
+        .perform(MockMvcRequestBuilders.delete("%s/negotiation-1".formatted(NEGOTIATIONS_URL)))
+        .andExpect(status().isNoContent());
+
+    assertFalse(negotiationRepository.findById("negotiation-1").isPresent());
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/UserNotificationServiceTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/UserNotificationServiceTest.java
@@ -177,7 +177,7 @@ class UserNotificationServiceTest {
       id = 109L,
       authorities = {"ROLE_ADMIN"})
   @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
-  void notifyRepresentatives_called2Times_noNewEmailsSent() {
+  void notifyRepresentatives_called2Times_noNewEmailsSent() throws InterruptedException {
     notificationEmailRepository.deleteAll();
     assertTrue(notificationEmailRepository.findAll().isEmpty());
     Negotiation negotiation = negotiationRepository.findAll().get(0);
@@ -186,6 +186,7 @@ class UserNotificationServiceTest {
             .anyMatch(resource -> !resource.getRepresentatives().isEmpty()));
     userNotificationService.notifyRepresentativesAboutNewNegotiation(negotiation);
     userNotificationService.sendEmailsForNewNotifications();
+    wait(100);
     int numOfEmails = notificationEmailRepository.findAll().size();
     assertTrue(numOfEmails > 0);
     userNotificationService.sendEmailsForNewNotifications();

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/UserNotificationServiceTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/UserNotificationServiceTest.java
@@ -29,6 +29,7 @@ import java.util.*;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.TestAbortedException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 @IntegrationTest(loadTestData = true)
 @Transactional
@@ -175,6 +176,7 @@ class UserNotificationServiceTest {
   @WithMockNegotiatorUser(
       id = 109L,
       authorities = {"ROLE_ADMIN"})
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
   void notifyRepresentatives_called2Times_noNewEmailsSent() {
     notificationEmailRepository.deleteAll();
     assertTrue(notificationEmailRepository.findAll().isEmpty());

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/UserNotificationServiceTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/UserNotificationServiceTest.java
@@ -1,5 +1,6 @@
 package eu.bbmri_eric.negotiator.integration.service;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,6 +27,7 @@ import eu.bbmri_eric.negotiator.util.IntegrationTest;
 import eu.bbmri_eric.negotiator.util.WithMockNegotiatorUser;
 import jakarta.transaction.Transactional;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.TestAbortedException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -177,7 +179,7 @@ class UserNotificationServiceTest {
       id = 109L,
       authorities = {"ROLE_ADMIN"})
   @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
-  void notifyRepresentatives_called2Times_noNewEmailsSent() throws InterruptedException {
+  void notifyRepresentatives_called2Times_noNewEmailsSent() {
     notificationEmailRepository.deleteAll();
     assertTrue(notificationEmailRepository.findAll().isEmpty());
     Negotiation negotiation = negotiationRepository.findAll().get(0);
@@ -186,10 +188,14 @@ class UserNotificationServiceTest {
             .anyMatch(resource -> !resource.getRepresentatives().isEmpty()));
     userNotificationService.notifyRepresentativesAboutNewNegotiation(negotiation);
     userNotificationService.sendEmailsForNewNotifications();
-    wait(100);
+    await()
+        .atMost(1, TimeUnit.SECONDS)
+        .until(() -> !notificationEmailRepository.findAll().isEmpty());
     int numOfEmails = notificationEmailRepository.findAll().size();
-    assertTrue(numOfEmails > 0);
     userNotificationService.sendEmailsForNewNotifications();
+    await()
+        .atMost(2, TimeUnit.SECONDS)
+        .until(() -> notificationEmailRepository.findAll().size() == numOfEmails);
     assertEquals(numOfEmails, notificationEmailRepository.findAll().size());
   }
 

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/unit/service/NegotiationServiceTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/unit/service/NegotiationServiceTest.java
@@ -1,5 +1,15 @@
 package eu.bbmri_eric.negotiator.unit.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import eu.bbmri_eric.negotiator.attachment.Attachment;
 import eu.bbmri_eric.negotiator.attachment.AttachmentRepository;
 import eu.bbmri_eric.negotiator.attachment.dto.AttachmentMetadataDTO;
@@ -22,6 +32,10 @@ import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.Negotiatio
 import eu.bbmri_eric.negotiator.notification.UserNotificationService;
 import eu.bbmri_eric.negotiator.user.PersonRepository;
 import eu.bbmri_eric.negotiator.util.WithMockNegotiatorUser;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import org.hibernate.exception.DataException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,21 +50,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
@@ -247,11 +246,11 @@ public class NegotiationServiceTest {
 
   @Test
   @WithMockNegotiatorUser(
-          id = 2L,
-          authName = "researcher",
-          authSubject = "researcher@aai.eu",
-          authEmail = "researcher@aai.eu",
-          authorities = {"ROLE_RESEARCHER"})
+      id = 2L,
+      authName = "researcher",
+      authSubject = "researcher@aai.eu",
+      authEmail = "researcher@aai.eu",
+      authorities = {"ROLE_RESEARCHER"})
   void testDeleteNegotiation_fails_when_CreatorIsDifferent() {
     Negotiation negotiation = Negotiation.builder().build();
     Request request = new Request();
@@ -261,16 +260,18 @@ public class NegotiationServiceTest {
     negotiation.setCurrentState(NegotiationState.DRAFT);
 
     when(personRepository.isNegotiationCreator(2L, "negotiation-id")).thenReturn(false);
-    assertThrows(ForbiddenRequestException.class, () -> negotiationService.deleteNegotiation(negotiation.getId()));
+    assertThrows(
+        ForbiddenRequestException.class,
+        () -> negotiationService.deleteNegotiation(negotiation.getId()));
   }
 
   @Test
   @WithMockNegotiatorUser(
-          id = 2L,
-          authName = "researcher",
-          authSubject = "researcher@aai.eu",
-          authEmail = "researcher@aai.eu",
-          authorities = {"ROLE_RESEARCHER"})
+      id = 2L,
+      authName = "researcher",
+      authSubject = "researcher@aai.eu",
+      authEmail = "researcher@aai.eu",
+      authorities = {"ROLE_RESEARCHER"})
   void testDeleteNegotiation_fails_when_notInDraftState() {
     Negotiation negotiation = Negotiation.builder().build();
     Request request = new Request();
@@ -281,16 +282,18 @@ public class NegotiationServiceTest {
 
     when(personRepository.isNegotiationCreator(2L, "negotiation-id")).thenReturn(true);
     when(negotiationRepository.findById("negotiation-id")).thenReturn(Optional.of(negotiation));
-    assertThrows(ConflictStatusException.class, () -> negotiationService.deleteNegotiation(negotiation.getId()));
+    assertThrows(
+        ConflictStatusException.class,
+        () -> negotiationService.deleteNegotiation(negotiation.getId()));
   }
 
   @Test
   @WithMockNegotiatorUser(
-          id = 2L,
-          authName = "researcher",
-          authSubject = "researcher@aai.eu",
-          authEmail = "researcher@aai.eu",
-          authorities = {"ROLE_RESEARCHER"})
+      id = 2L,
+      authName = "researcher",
+      authSubject = "researcher@aai.eu",
+      authEmail = "researcher@aai.eu",
+      authorities = {"ROLE_RESEARCHER"})
   void testDeleteNegotiation_fails_when_negotiationNotFound() {
     Negotiation negotiation = Negotiation.builder().build();
     Request request = new Request();
@@ -301,16 +304,18 @@ public class NegotiationServiceTest {
 
     when(personRepository.isNegotiationCreator(2L, "negotiation-id")).thenReturn(true);
     when(negotiationRepository.findById("negotiation-id")).thenReturn(Optional.empty());
-    assertThrows(EntityNotFoundException.class, () -> negotiationService.deleteNegotiation(negotiation.getId()));
+    assertThrows(
+        EntityNotFoundException.class,
+        () -> negotiationService.deleteNegotiation(negotiation.getId()));
   }
 
   @Test
   @WithMockNegotiatorUser(
-          id = 2L,
-          authName = "researcher",
-          authSubject = "researcher@aai.eu",
-          authEmail = "researcher@aai.eu",
-          authorities = {"ROLE_RESEARCHER"})
+      id = 2L,
+      authName = "researcher",
+      authSubject = "researcher@aai.eu",
+      authEmail = "researcher@aai.eu",
+      authorities = {"ROLE_RESEARCHER"})
   void testDeleteNegotiation_ok() {
     Negotiation negotiation = Negotiation.builder().build();
     Request request = new Request();

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/unit/service/NegotiationServiceTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/unit/service/NegotiationServiceTest.java
@@ -316,7 +316,7 @@ public class NegotiationServiceTest {
       authSubject = "researcher@aai.eu",
       authEmail = "researcher@aai.eu",
       authorities = {"ROLE_RESEARCHER"})
-  void testDeleteNegotiation_ok() {
+  void testDeleteNegotiation_ok_whenCreator() {
     Negotiation negotiation = Negotiation.builder().build();
     Request request = new Request();
     request.setResources(Set.of(new Resource()));
@@ -325,6 +325,25 @@ public class NegotiationServiceTest {
     negotiation.setCurrentState(NegotiationState.DRAFT);
 
     when(personRepository.isNegotiationCreator(2L, "negotiation-id")).thenReturn(true);
+    when(negotiationRepository.findById("negotiation-id")).thenReturn(Optional.of(negotiation));
+    negotiationService.deleteNegotiation(negotiation.getId());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(
+      authName = "admin",
+      authSubject = "admin@negotiator.dev",
+      authEmail = "admin@negotiator.dev",
+      authorities = {"ROLE_ADMIN"})
+  void testDeleteNegotiation_ok_whenAdministrator() {
+    Negotiation negotiation = Negotiation.builder().build();
+    Request request = new Request();
+    request.setResources(Set.of(new Resource()));
+    negotiation.setId("negotiation-id");
+    negotiation.setResources(request.getResources());
+    negotiation.setCurrentState(NegotiationState.DRAFT);
+
+    when(personRepository.isNegotiationCreator(2L, "negotiation-id")).thenReturn(false);
     when(negotiationRepository.findById("negotiation-id")).thenReturn(Optional.of(negotiation));
     negotiationService.deleteNegotiation(negotiation.getId());
   }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/unit/service/NegotiationServiceTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/unit/service/NegotiationServiceTest.java
@@ -259,6 +259,7 @@ public class NegotiationServiceTest {
     negotiation.setResources(request.getResources());
     negotiation.setCurrentState(NegotiationState.DRAFT);
 
+    when(negotiationRepository.findById("negotiation-id")).thenReturn(Optional.of(negotiation));
     when(personRepository.isNegotiationCreator(2L, "negotiation-id")).thenReturn(false);
     assertThrows(
         ForbiddenRequestException.class,

--- a/frontend/src/store/negotiationPage.js
+++ b/frontend/src/store/negotiationPage.js
@@ -302,6 +302,17 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
       })
   }
 
+  async function deleteNegotiation(negotiationId) {
+    return axios
+      .delete(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}`, { headers: getBearerHeaders() })
+      .then(() => {
+        notifications.setNotification(`Negotiation with id ${negotiationId} deleted successfully`)
+      })
+      .catch(() => {
+        notifications.setNotification('Error deleting negotiation')
+      })
+  }
+
   return {
     updateNegotiationStatus,
     retrievePossibleEvents,
@@ -323,5 +334,6 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
     addResources,
     retrieveAllResources,
     retrieveResourceAllStates,
+    deleteNegotiation
   }
 })

--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -300,7 +300,7 @@
             </ul>
           </li>
           <li
-            v-else-if="negotiation.status === 'DRAFT'"
+            v-else-if="isDeletable()"
             class="list-group-item p-2 d-flex justify-content-between">
             <ul class="list-unstyled mt-1 d-flex flex-row flex-wrap">
               <li class="me-2">
@@ -347,6 +347,7 @@
 
 <script setup>
 import { computed, onBeforeMount, onMounted, ref } from 'vue'
+import { ROLES } from '@/config/consts'
 import NegotiationPosts from '@/components/NegotiationPosts.vue'
 import ConfirmationModal from '@/components/modals/ConfirmationModal.vue'
 import NegotiationAttachment from '@/components/NegotiationAttachment.vue'
@@ -440,6 +441,14 @@ const organizationsById = computed(() => {
   }, {})
 })
 
+const userInfo = computed(() => {
+  return userStore.userInfo
+})
+
+const isAdmin = computed(() => {
+  return userInfo.value.roles.includes(ROLES.ADMINISTRATOR)
+})
+
 const representedOrganizationsById = computed(() => {
   return Object.entries(organizationsById.value)
     .filter(
@@ -469,6 +478,7 @@ function isResourceRepresented(resource) {
 const numberOfResources = computed(() => {
   return getResources.value.length
 })
+
 const postsRecipients = computed(() => {
   return organizations.value.map((org) => {
     return { id: org.externalId, name: org.name }
@@ -478,9 +488,11 @@ const postsRecipients = computed(() => {
 function assignStatus(status) {
   selectedStatus.value = status
 }
+
 const author = computed(() => {
   return negotiation.value.author
 })
+
 const loading = computed(() => {
   return negotiation.value === undefined || resources.value.length === 0
 })
@@ -551,6 +563,10 @@ async function updateNegotiation(message) {
   await reloadStates()
 
   negotiationPosts.value.retrievePostsByNegotiationId()
+}
+
+function isDeletable() {
+  return negotiation.value.status === 'DRAFT' && (isAdmin.value || userInfo.value.subjectId === negotiation.value.author.subjectId)
 }
 
 async function deleteNegotiation() {

--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -15,6 +15,14 @@
       :message-enabled="false"
       @confirm="updateNegotiationPayload()"
     />
+
+    <confirmation-modal
+      id="negotiationDeleteModal"
+      title="Negotiation delete"
+      text="Are you sure you want to delete the Negotiation. All your data will be lost."
+      :message-enabled="false"
+      @confirm="deleteNegotiation()"
+    />
     <div class="row mt-4">
       <div class="row-col-2">
         <h1 class="fw-bold" :style="{ color: uiConfiguration.primaryTextColor }">
@@ -291,6 +299,21 @@
               </li>
             </ul>
           </li>
+          <li
+            v-else-if="negotiation.status === 'DRAFT'"
+            class="list-group-item p-2 d-flex justify-content-between">
+            <ul class="list-unstyled mt-1 d-flex flex-row flex-wrap">
+              <li class="me-2">
+                <button
+                  class="btn btn-status bg-danger mb-1 d-flex text-left"
+                  data-bs-toggle="modal"
+                  data-bs-target="#negotiationDeleteModal"
+                >
+                  <i class="bi bi-trash" /> DELETE
+                </button>
+              </li>
+            </ul>
+          </li>
 
           <li class="list-group-item p-2 btn-sm border-bottom-0">
             <PDFButton class="mt-2" :negotiation-pdf-data="negotiation" />
@@ -528,6 +551,10 @@ async function updateNegotiation(message) {
   await reloadStates()
 
   negotiationPosts.value.retrievePostsByNegotiationId()
+}
+
+async function deleteNegotiation() {
+  await negotiationPageStore.deleteNegotiation(negotiation.value.id).then(router.push('/'))
 }
 
 function getSummaryLinks(links) {

--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -300,7 +300,7 @@
             </ul>
           </li>
           <li
-            v-else-if="isDeletable()"
+            v-else-if="canDelete()"
             class="list-group-item p-2 d-flex justify-content-between">
             <ul class="list-unstyled mt-1 d-flex flex-row flex-wrap">
               <li class="me-2">
@@ -314,7 +314,6 @@
               </li>
             </ul>
           </li>
-
           <li class="list-group-item p-2 btn-sm border-bottom-0">
             <PDFButton class="mt-2" :negotiation-pdf-data="negotiation" />
           </li>
@@ -565,7 +564,7 @@ async function updateNegotiation(message) {
   negotiationPosts.value.retrievePostsByNegotiationId()
 }
 
-function isDeletable() {
+function canDelete() {
   return negotiation.value.status === 'DRAFT' && (isAdmin.value || userInfo.value.subjectId === negotiation.value.author.subjectId)
 }
 


### PR DESCRIPTION
## Negotiator pull request:

### Description:

This PR allows the user to delete a Negotiation in DRAFT state. The operation is only allowed when the user is the 
creator of the negotiation or the negotiator administrator.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [*] I have performed a self-review of my code
- [*] I have made my code as simple as possible
- [*] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [*] I have removed all commented code
- [*] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [ *] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
