### PR TITLE
fix: allow admin to upload attachments for a Negotiation

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/DBAttachmentService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/attachment/DBAttachmentService.java
@@ -156,7 +156,8 @@ public class DBAttachmentService implements AttachmentService {
     // checks whether the user is representative of the organization
     if (organizationExternalId != null
         && !negotiationService.isNegotiationCreator(negotiationId)
-        && !isRepresentativeOfOrganization(organizationExternalId)) {
+        && !isRepresentativeOfOrganization(organizationExternalId)
+        && !isAdmin()) {
       throw new ForbiddenRequestException(
           "User %s is not authorized to upload attachments to this organization for this negotiation"
               .formatted(userId));

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
@@ -96,7 +96,8 @@ public class NegotiationServiceImpl implements NegotiationService {
   public boolean isAuthorizedForNegotiation(String negotiationId) {
     return isNegotiationCreator(negotiationId)
         || personService.isRepresentativeOfAnyResourceOfNegotiation(
-            AuthenticatedUserContext.getCurrentlyAuthenticatedUserInternalId(), negotiationId);
+            AuthenticatedUserContext.getCurrentlyAuthenticatedUserInternalId(), negotiationId)
+        || AuthenticatedUserContext.isCurrentlyAuthenticatedUserAdmin();
   }
 
   public boolean isOrganizationPartOfNegotiation(


### PR DESCRIPTION
## Negotiator pull request:

### Description:

 Allow admin to upload attachments for a Negotiation

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
