### PR TITLE
feat: add searching for Users

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/LinkBuilder.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/LinkBuilder.java
@@ -49,14 +49,14 @@ public class LinkBuilder {
     return links;
   }
 
-  private static String createBaseUriBuilder(URI baseUri, FilterDTO filterDTO) {
+  public static String createBaseUriBuilder(URI baseUri, FilterDTO filterDTO) {
     return UriComponentsBuilder.fromUri(baseUri)
         .queryParams(getQueryParams(filterDTO))
         .build()
         .toString();
   }
 
-  private static MultiValueMap<String, String> getQueryParams(Object filterDTO) {
+  protected static MultiValueMap<String, String> getQueryParams(Object filterDTO) {
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     Field[] fields = filterDTO.getClass().getDeclaredFields();
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/LinkBuilder.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/LinkBuilder.java
@@ -56,7 +56,7 @@ public class LinkBuilder {
         .toString();
   }
 
-  protected static MultiValueMap<String, String> getQueryParams(Object filterDTO) {
+  protected static MultiValueMap<String, String> getQueryParams(FilterDTO filterDTO) {
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     Field[] fields = filterDTO.getClass().getDeclaredFields();
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonService.java
@@ -1,8 +1,6 @@
 package eu.bbmri_eric.negotiator.user;
 
 import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
-import eu.bbmri_eric.negotiator.common.exceptions.UnsupportedFilterException;
-import eu.bbmri_eric.negotiator.common.exceptions.WrongSortingPropertyException;
 import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceResponseModel;
 import java.util.List;
 import java.util.Set;
@@ -19,24 +17,31 @@ public interface PersonService {
   UserResponseModel findById(Long id) throws EntityNotFoundException;
 
   /**
-   * Retrieves all UserResponseModels that match the specified filter criteria.
-   *
-   * @param property the property to filter on
-   * @param matchedValue the value that must be matched
-   * @return an Iterable of UserResponseModel objects that match the filter criteria
-   */
-  Iterable<UserResponseModel> findAllByFilter(
-      String property, String matchedValue, int page, int size) throws UnsupportedFilterException;
-
-  /**
    * Retrieves a page of people.
    *
-   * @param page the page to retrieve.
-   * @param size the size of the page.
    * @return a page of people.
    */
-  Iterable<UserResponseModel> findAll(int page, int size);
+  Iterable<UserResponseModel> findAllByFilters(UserFilterDTO filters);
 
+  //  /**
+  //   * Retrieves a page of people.
+  //   *
+  //   * @param page the page to retrieve.
+  //   * @param size the size of the page.
+  //   * @return a page of people.
+  //   */
+  //  Iterable<UserResponseModel> findAll(int page, int size);
+  //
+  //  /**
+  //   * Retrieves page of people from a sorted list.
+  //   *
+  //   * @param page the page to retrieve.
+  //   * @param size the size of the page.
+  //   * @param sort the property to sort by.
+  //   * @return a page of people.
+  //   */
+  //  Iterable<UserResponseModel> findAll(int page, int size, String sort)
+  //      throws WrongSortingPropertyException;
   List<UserResponseModel> findAllByOrganizationId(Long id);
 
   /**

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonService.java
@@ -19,41 +19,18 @@ public interface PersonService {
   /**
    * Retrieves a page of people.
    *
+   * @param filters a UserFilterDTO with filters to apply and paging and sorting information
    * @return a page of people.
    */
   Iterable<UserResponseModel> findAllByFilters(UserFilterDTO filters);
 
-  //  /**
-  //   * Retrieves a page of people.
-  //   *
-  //   * @param page the page to retrieve.
-  //   * @param size the size of the page.
-  //   * @return a page of people.
-  //   */
-  //  Iterable<UserResponseModel> findAll(int page, int size);
-  //
-  //  /**
-  //   * Retrieves page of people from a sorted list.
-  //   *
-  //   * @param page the page to retrieve.
-  //   * @param size the size of the page.
-  //   * @param sort the property to sort by.
-  //   * @return a page of people.
-  //   */
-  //  Iterable<UserResponseModel> findAll(int page, int size, String sort)
-  //      throws WrongSortingPropertyException;
-  List<UserResponseModel> findAllByOrganizationId(Long id);
-
   /**
-   * Retrieves page of people from a sorted list.
+   * Retrieves a page of people filterer by the Organization they belong to
    *
-   * @param page the page to retrieve.
-   * @param size the size of the page.
-   * @param sort the property to sort by.
-   * @return a page of people.
+   * @param id The id of the Organization
+   * @return a page of people
    */
-  Iterable<UserResponseModel> findAll(int page, int size, String sort)
-      throws WrongSortingPropertyException;
+  List<UserResponseModel> findAllByOrganizationId(Long id);
 
   /**
    * Checks if the person with the specified id represents any of the resources in the list.

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonServiceImpl.java
@@ -2,7 +2,6 @@ package eu.bbmri_eric.negotiator.user;
 
 import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
 import eu.bbmri_eric.negotiator.common.exceptions.UserNotFoundException;
-import eu.bbmri_eric.negotiator.common.exceptions.WrongSortingPropertyException;
 import eu.bbmri_eric.negotiator.governance.network.Network;
 import eu.bbmri_eric.negotiator.governance.network.NetworkRepository;
 import eu.bbmri_eric.negotiator.governance.resource.Resource;
@@ -20,7 +19,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -80,35 +78,10 @@ public class PersonServiceImpl implements PersonService {
   }
 
   @Override
-  public Iterable<UserResponseModel> findAll(int page, int size) {
-    if (page < 0) throw new IllegalArgumentException("Page must be greater than 0.");
-    if (size < 1) throw new IllegalArgumentException("Size must be greater than 0.");
-    Page<UserResponseModel> result =
-        personRepository
-            .findAll(PageRequest.of(page, size))
-            .map(person -> modelMapper.map(person, UserResponseModel.class));
-    if (page > result.getTotalPages())
-      throw new IllegalArgumentException(
-          "For the given size the page must be less than/equal to " + result.getTotalPages() + ".");
-    return result;
-  }
-
-  @Override
   public List<UserResponseModel> findAllByOrganizationId(Long id) {
     return personRepository.findAllByOrganizationId(id).stream()
         .map(person -> modelMapper.map(person, UserResponseModel.class))
         .toList();
-  }
-
-  @Override
-  public Iterable<UserResponseModel> findAll(int page, int size, String sortProperty) {
-    try {
-      return personRepository
-          .findAll(PageRequest.of(page, size, Sort.by(sortProperty)))
-          .map(person -> modelMapper.map(person, UserResponseModel.class));
-    } catch (PropertyReferenceException e) {
-      throw new WrongSortingPropertyException(sortProperty, "name, id, email, organization");
-    }
   }
 
   @Override

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonServiceImpl.java
@@ -1,7 +1,6 @@
 package eu.bbmri_eric.negotiator.user;
 
 import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
-import eu.bbmri_eric.negotiator.common.exceptions.UnsupportedFilterException;
 import eu.bbmri_eric.negotiator.common.exceptions.UserNotFoundException;
 import eu.bbmri_eric.negotiator.common.exceptions.WrongSortingPropertyException;
 import eu.bbmri_eric.negotiator.governance.network.Network;
@@ -10,8 +9,6 @@ import eu.bbmri_eric.negotiator.governance.resource.Resource;
 import eu.bbmri_eric.negotiator.governance.resource.ResourceRepository;
 import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceResponseModel;
 import jakarta.transaction.Transactional;
-import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -22,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.stereotype.Service;
 
@@ -56,30 +54,18 @@ public class PersonServiceImpl implements PersonService {
   }
 
   @Override
-  public Iterable<UserResponseModel> findAllByFilter(
-      String property, String matchedValue, int page, int size) {
-    if (page < 0) throw new IllegalArgumentException("Page must be greater than 0.");
-    if (size < 1) throw new IllegalArgumentException("Size must be greater than 0.");
-    if (Arrays.stream(UserResponseModel.class.getDeclaredFields())
-        .anyMatch(field -> field.getName().equals(property))) {
-      Page<UserResponseModel> result =
-          personRepository
-              .findAll(
-                  PersonSpecifications.propertyEquals(property, matchedValue),
-                  PageRequest.of(page, size))
-              .map(person -> modelMapper.map(person, UserResponseModel.class));
-      if (page > result.getTotalPages())
-        throw new IllegalArgumentException(
-            "For the given size the page must be less than/equal to "
-                + result.getTotalPages()
-                + ".");
-      return result;
-    } else
-      throw new UnsupportedFilterException(
-          property,
-          Arrays.stream(UserResponseModel.class.getFields())
-              .map(Field::getName)
-              .toArray(String[]::new));
+  public Iterable<UserResponseModel> findAllByFilters(UserFilterDTO filtersDTO) {
+    Specification<Person> filtersSpec = PersonSpecifications.fromUserFilters(filtersDTO);
+
+    Pageable pageable =
+        PageRequest.of(
+            filtersDTO.getPage(),
+            filtersDTO.getSize(),
+            Sort.by(filtersDTO.getSortOrder(), filtersDTO.getSortBy().name()));
+
+    return personRepository
+        .findAll(filtersSpec, pageable)
+        .map(person -> modelMapper.map(person, UserResponseModel.class));
   }
 
   @Override

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonServiceImpl.java
@@ -56,12 +56,13 @@ public class PersonServiceImpl implements PersonService {
   @Override
   public Iterable<UserResponseModel> findAllByFilters(UserFilterDTO filtersDTO) {
     Specification<Person> filtersSpec = PersonSpecifications.fromUserFilters(filtersDTO);
-
     Pageable pageable =
         PageRequest.of(
             filtersDTO.getPage(),
             filtersDTO.getSize(),
-            Sort.by(filtersDTO.getSortOrder(), filtersDTO.getSortBy().name()));
+            Sort.by(
+                new Sort.Order(filtersDTO.getSortOrder(), filtersDTO.getSortBy().name())
+                    .ignoreCase()));
 
     return personRepository
         .findAll(filtersSpec, pageable)

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonSpecifications.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonSpecifications.java
@@ -7,6 +7,10 @@ public class PersonSpecifications {
 
   public static Specification<Person> fromUserFilters(UserFilterDTO filtersDTO) {
     Specification<Person> specs = null;
+    if (filtersDTO.getId() != null) {
+      specs = initOrAnd(specs, propertyEquals("id", filtersDTO.getId()));
+    }
+
     if (filtersDTO.getName() != null) {
       specs = initOrAnd(specs, nameContains(filtersDTO.getName()));
     }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonSpecifications.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonSpecifications.java
@@ -4,9 +4,44 @@ import org.springframework.data.jpa.domain.Specification;
 
 /** This class provides specifications for querying the Person entity. */
 public class PersonSpecifications {
+
+  public static Specification<Person> fromUserFilters(UserFilterDTO filtersDTO) {
+    Specification<Person> specs = null;
+    if (filtersDTO.getName() != null) {
+      specs = initOrAnd(specs, nameContains(filtersDTO.getName()));
+    }
+
+    if (filtersDTO.getEmail() != null) {
+      specs = initOrAnd(specs, propertyEquals("email", filtersDTO.getEmail()));
+    }
+
+    if (filtersDTO.getSubjectId() != null) {
+      specs = initOrAnd(specs, propertyEquals("subjectId", filtersDTO.getSubjectId()));
+    }
+
+    if (filtersDTO.getIsAdmin() != null) {
+      specs = initOrAnd(specs, isAdmin(filtersDTO.getIsAdmin()));
+    }
+
+    return specs;
+  }
+
+  private static Specification<Person> initOrAnd(
+      Specification<Person> overallSpec, Specification<Person> newSpec) {
+    if (overallSpec == null) {
+      return newSpec;
+    } else {
+      return overallSpec.and(newSpec);
+    }
+  }
+
   public static Specification<Person> nameContains(String substring) {
     return (root, query, criteriaBuilder) ->
         criteriaBuilder.like(root.get("name"), "%" + substring + "%");
+  }
+
+  public static Specification<Person> isAdmin(Boolean isAdmin) {
+    return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("admin"), isAdmin);
   }
 
   public static Specification<Person> propertyEquals(String property, String matchedString) {

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonSpecifications.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/PersonSpecifications.java
@@ -12,15 +12,15 @@ public class PersonSpecifications {
     }
 
     if (filtersDTO.getName() != null) {
-      specs = initOrAnd(specs, nameContains(filtersDTO.getName()));
+      specs = initOrAnd(specs, propertyContains("name", filtersDTO.getName()));
     }
 
     if (filtersDTO.getEmail() != null) {
-      specs = initOrAnd(specs, propertyEquals("email", filtersDTO.getEmail()));
+      specs = initOrAnd(specs, propertyContains("email", filtersDTO.getEmail()));
     }
 
     if (filtersDTO.getSubjectId() != null) {
-      specs = initOrAnd(specs, propertyEquals("subjectId", filtersDTO.getSubjectId()));
+      specs = initOrAnd(specs, propertyContains("subjectId", filtersDTO.getSubjectId()));
     }
 
     if (filtersDTO.getIsAdmin() != null) {
@@ -39,11 +39,6 @@ public class PersonSpecifications {
     }
   }
 
-  public static Specification<Person> nameContains(String substring) {
-    return (root, query, criteriaBuilder) ->
-        criteriaBuilder.like(root.get("name"), "%" + substring + "%");
-  }
-
   public static Specification<Person> isAdmin(Boolean isAdmin) {
     return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("admin"), isAdmin);
   }
@@ -51,5 +46,11 @@ public class PersonSpecifications {
   public static Specification<Person> propertyEquals(String property, String matchedString) {
     return (root, query, criteriaBuilder) ->
         criteriaBuilder.equal(root.get(property), matchedString);
+  }
+
+  public static Specification<Person> propertyContains(String property, String substring) {
+    return (root, query, criteriaBuilder) ->
+        criteriaBuilder.like(
+            criteriaBuilder.lower(root.get(property)), "%" + substring.toLowerCase() + "%");
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserController.java
@@ -51,7 +51,7 @@ public class UserController {
   @ResponseStatus(HttpStatus.OK)
   @Operation(
       summary = "List all users",
-      description = "For filtering use for example: ?email=example@email.com")
+      description = "For filtering use for example: ?name=John&email=example@email.com")
   public PagedModel<EntityModel<UserResponseModel>> listUsers(
       @Valid @Nullable @ParameterObject UserFilterDTO filters) {
     if (AuthenticatedUserContext.getRoles().contains("ROLE_AUTHORIZATION_MANAGER")

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserController.java
@@ -10,10 +10,10 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.extern.apachecommons.CommonsLog;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -22,6 +22,7 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -52,15 +53,11 @@ public class UserController {
       summary = "List all users",
       description = "For filtering use for example: ?email=example@email.com")
   public PagedModel<EntityModel<UserResponseModel>> listUsers(
-      @RequestParam(required = false) Map<String, String> filterProperty,
-      @RequestParam(required = false, defaultValue = "0") int page,
-      @RequestParam(required = false, defaultValue = "50") int size) {
+      @Valid @Nullable @ParameterObject UserFilterDTO filters) {
     if (AuthenticatedUserContext.getRoles().contains("ROLE_AUTHORIZATION_MANAGER")
         || AuthenticatedUserContext.isCurrentlyAuthenticatedUserAdmin()) {
-      if (Objects.nonNull(filterProperty) && !filterProperty.isEmpty()) {
-        return filteredPageModel(filterProperty, page, size);
-      }
-      return assembler.toPagedModel((Page<UserResponseModel>) personService.findAll(page, size));
+      return assembler.toPagedModel(
+          (Page<UserResponseModel>) personService.findAllByFilters(filters), filters);
     } else {
       return assembler.toPagedModel(
           personService.findById(
@@ -74,23 +71,6 @@ public class UserController {
     return assembler.toModel(
         personService.findById(AuthenticatedUserContext.getCurrentlyAuthenticatedUserInternalId()),
         AuthenticatedUserContext.getRoles());
-  }
-
-  private PagedModel<EntityModel<UserResponseModel>> filteredPageModel(
-      Map<String, String> filterProperty, int page, int size) {
-    filterProperty.remove("page");
-    filterProperty.remove("size");
-    if (filterProperty.isEmpty()) {
-      return assembler.toPagedModel((Page<UserResponseModel>) personService.findAll(page, size));
-    } else {
-      Iterable<UserResponseModel> users =
-          personService.findAllByFilter(
-              filterProperty.keySet().iterator().next(),
-              filterProperty.values().iterator().next(),
-              page,
-              size);
-      return assembler.toPagedModel((Page<UserResponseModel>) users);
-    }
   }
 
   /**

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserFilterDTO.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserFilterDTO.java
@@ -3,6 +3,7 @@ package eu.bbmri_eric.negotiator.user;
 import eu.bbmri_eric.negotiator.common.FilterDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +32,14 @@ public class UserFilterDTO implements FilterDTO {
 
   @Schema(description = "Whether the user is admin or not")
   Boolean isAdmin;
+
+  @Schema(description = "The date after which the last login was performed", example = "2024-11-18")
+  LocalDate lastLoginAfter;
+
+  @Schema(
+      description = "The date before which the last login was performed",
+      example = "2024-11-18")
+  LocalDate lastLoginBefore;
 
   @Schema(
       description = "The field to use to sort the results",

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserFilterDTO.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserFilterDTO.java
@@ -1,0 +1,48 @@
+package eu.bbmri_eric.negotiator.user;
+
+import eu.bbmri_eric.negotiator.common.FilterDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.domain.Sort;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "Parameters to filter the users")
+public class UserFilterDTO implements FilterDTO {
+  @Schema(description = "The name of the user")
+  String name;
+
+  @Schema(description = "The email of the user")
+  String email;
+
+  @Schema(description = "The subjectId of the user")
+  String subjectId;
+
+  @Schema(description = "Whether the user is admin or not")
+  Boolean isAdmin;
+
+  @Schema(
+      description = "The field to use to sort the results",
+      example = "name",
+      defaultValue = "lastLogin")
+  UserSortField sortBy = UserSortField.lastLogin;
+
+  @Schema(description = "The direction of the sorting", example = "DESC")
+  Sort.Direction sortOrder = Sort.Direction.DESC;
+
+  @Schema(description = "The page number required", example = "0")
+  @Min(value = 0, message = "Page number must be greater than or equal to 0")
+  int page = 0;
+
+  @Schema(description = "The size of the pages required", example = "50")
+  @Min(value = 1, message = "Page size must be greater than or equal to 1")
+  int size = 50;
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserFilterDTO.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserFilterDTO.java
@@ -17,6 +17,9 @@ import org.springframework.data.domain.Sort;
 @Builder
 @Schema(description = "Parameters to filter the users")
 public class UserFilterDTO implements FilterDTO {
+  @Schema(description = "The ID of the user")
+  String id;
+
   @Schema(description = "The name of the user")
   String name;
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserModelAssembler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserModelAssembler.java
@@ -90,13 +90,36 @@ public class UserModelAssembler
     return links;
   }
 
-  public PagedModel<EntityModel<UserResponseModel>> toPagedModel(Page<UserResponseModel> page) {
-    List<Link> links = getLinks(page);
-    return PagedModel.of(
-        page.getContent().stream().map(this::toModel).collect(Collectors.toList()),
-        new PagedModel.PageMetadata(
-            page.getSize(), page.getNumber(), page.getTotalElements(), page.getTotalPages()),
-        links);
+  @NonNull
+  private static List<Link> getLinks(Page<UserResponseModel> page, UserFilterDTO filters) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("filter", null);
+    List<Link> links = new ArrayList<>();
+    if (page.hasPrevious()) {
+      links.add(
+          linkTo(methodOn(UserController.class).listUsers(filters))
+              .withRel(IanaLinkRelations.PREVIOUS)
+              .expand(parameters));
+    }
+    if (page.hasNext()) {
+      links.add(
+          linkTo(methodOn(UserController.class).listUsers(filters))
+              .withRel(IanaLinkRelations.NEXT)
+              .expand(parameters));
+    }
+    links.add(
+        linkTo(methodOn(UserController.class).listUsers(filters))
+            .withRel("first")
+            .expand(parameters));
+    links.add(
+        linkTo(methodOn(UserController.class).listUsers(filters))
+            .withRel(IanaLinkRelations.CURRENT)
+            .expand());
+    links.add(
+        linkTo(methodOn(UserController.class).listUsers(filters))
+            .withRel(IanaLinkRelations.LAST)
+            .expand(parameters));
+    return links;
   }
 
   public PagedModel<EntityModel<UserResponseModel>> toPagedModel(UserResponseModel entity) {
@@ -111,41 +134,13 @@ public class UserModelAssembler
             page.getSize(), page.getNumber(), page.getTotalElements(), page.getTotalPages()));
   }
 
-  @NonNull
-  private static List<Link> getLinks(Page<UserResponseModel> page) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("filter", null);
-    List<Link> links = new ArrayList<>();
-    if (page.hasPrevious()) {
-      links.add(
-          linkTo(
-                  methodOn(UserController.class)
-                      .listUsers(null, page.getNumber() - 1, page.getSize()))
-              .withRel(IanaLinkRelations.PREVIOUS)
-              .expand(parameters));
-    }
-    if (page.hasNext()) {
-      links.add(
-          linkTo(
-                  methodOn(UserController.class)
-                      .listUsers(null, page.getNumber() + 1, page.getSize()))
-              .withRel(IanaLinkRelations.NEXT)
-              .expand(parameters));
-    }
-    links.add(
-        linkTo(methodOn(UserController.class).listUsers(null, 0, page.getSize()))
-            .withRel("first")
-            .expand(parameters));
-    links.add(
-        linkTo(methodOn(UserController.class).listUsers(null, page.getNumber(), page.getSize()))
-            .withRel(IanaLinkRelations.CURRENT)
-            .expand());
-    links.add(
-        linkTo(
-                methodOn(UserController.class)
-                    .listUsers(null, page.getTotalPages() - 1, page.getSize()))
-            .withRel(IanaLinkRelations.LAST)
-            .expand(parameters));
-    return links;
+  public PagedModel<EntityModel<UserResponseModel>> toPagedModel(
+      Page<UserResponseModel> page, UserFilterDTO filters) {
+    List<Link> links = getLinks(page, filters);
+    return PagedModel.of(
+        page.getContent().stream().map(this::toModel).collect(Collectors.toList()),
+        new PagedModel.PageMetadata(
+            page.getSize(), page.getNumber(), page.getTotalElements(), page.getTotalPages()),
+        links);
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserModelAssembler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserModelAssembler.java
@@ -1,15 +1,16 @@
 package eu.bbmri_eric.negotiator.user;
 
+import static eu.bbmri_eric.negotiator.common.LinkBuilder.createBaseUriBuilder;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
+import eu.bbmri_eric.negotiator.common.FilterDTO;
 import eu.bbmri_eric.negotiator.negotiation.NegotiationController;
 import eu.bbmri_eric.negotiator.negotiation.NegotiationRole;
 import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationFilterDTO;
+import java.net.URI;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import org.springframework.data.domain.Page;
@@ -90,35 +91,27 @@ public class UserModelAssembler
     return links;
   }
 
-  @NonNull
-  private static List<Link> getLinks(Page<UserResponseModel> page, UserFilterDTO filters) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("filter", null);
+  public static @NonNull List<Link> getPageLinks(
+      URI baseUri, FilterDTO filterDTO, PagedModel.PageMetadata pageMetadata) {
     List<Link> links = new ArrayList<>();
-    if (page.hasPrevious()) {
+
+    links.add(Link.of(createBaseUriBuilder(baseUri, filterDTO)).withRel(IanaLinkRelations.CURRENT));
+    final int currentPage = filterDTO.getPage();
+    if (pageMetadata.getNumber() > 0) {
+      filterDTO.setPage(0);
+      links.add(Link.of(createBaseUriBuilder(baseUri, filterDTO)).withRel(IanaLinkRelations.FIRST));
+      filterDTO.setPage(currentPage - 1);
       links.add(
-          linkTo(methodOn(UserController.class).listUsers(filters))
-              .withRel(IanaLinkRelations.PREVIOUS)
-              .expand(parameters));
+          Link.of(createBaseUriBuilder(baseUri, filterDTO)).withRel(IanaLinkRelations.PREVIOUS));
     }
-    if (page.hasNext()) {
-      links.add(
-          linkTo(methodOn(UserController.class).listUsers(filters))
-              .withRel(IanaLinkRelations.NEXT)
-              .expand(parameters));
+
+    if (pageMetadata.getNumber() < pageMetadata.getTotalPages() - 1) {
+      filterDTO.setPage(currentPage + 1);
+      links.add(Link.of(createBaseUriBuilder(baseUri, filterDTO)).withRel(IanaLinkRelations.NEXT));
+      filterDTO.setPage((int) pageMetadata.getTotalPages() - 1);
+      links.add(Link.of(createBaseUriBuilder(baseUri, filterDTO)).withRel(IanaLinkRelations.LAST));
     }
-    links.add(
-        linkTo(methodOn(UserController.class).listUsers(filters))
-            .withRel("first")
-            .expand(parameters));
-    links.add(
-        linkTo(methodOn(UserController.class).listUsers(filters))
-            .withRel(IanaLinkRelations.CURRENT)
-            .expand());
-    links.add(
-        linkTo(methodOn(UserController.class).listUsers(filters))
-            .withRel(IanaLinkRelations.LAST)
-            .expand(parameters));
+
     return links;
   }
 
@@ -135,8 +128,19 @@ public class UserModelAssembler
   }
 
   public PagedModel<EntityModel<UserResponseModel>> toPagedModel(
-      Page<UserResponseModel> page, UserFilterDTO filters) {
-    List<Link> links = getLinks(page, filters);
+      @NonNull Page<UserResponseModel> page, UserFilterDTO filters) {
+
+    List<Link> links = new ArrayList<>();
+    if (page.hasContent()) {
+      PagedModel.PageMetadata pageMetadata =
+          new PagedModel.PageMetadata(
+              page.getSize(), page.getNumber(), page.getTotalElements(), page.getTotalPages());
+      links =
+          getPageLinks(
+              linkTo(methodOn(UserController.class).listUsers(filters)).toUri(),
+              filters,
+              pageMetadata);
+    }
     return PagedModel.of(
         page.getContent().stream().map(this::toModel).collect(Collectors.toList()),
         new PagedModel.PageMetadata(

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserSortField.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserSortField.java
@@ -1,0 +1,7 @@
+package eu.bbmri_eric.negotiator.user;
+
+public enum UserSortField {
+  name,
+  email,
+  lastLogin
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserSortField.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserSortField.java
@@ -1,6 +1,7 @@
 package eu.bbmri_eric.negotiator.user;
 
 public enum UserSortField {
+  subjectId,
   name,
   email,
   lastLogin

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserSortField.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/user/UserSortField.java
@@ -1,6 +1,7 @@
 package eu.bbmri_eric.negotiator.user;
 
 public enum UserSortField {
+  id,
   subjectId,
   name,
   email,

--- a/backend/src/main/resources/db/test/migration/R__Initial_data.sql
+++ b/backend/src/main/resources/db/test/migration/R__Initial_data.sql
@@ -1,18 +1,18 @@
 insert into discovery_service (url, name)
 values ('http://discoveryservice.dev','Biobank Directory');
 
-insert into person (id, email, name, subject_id, password, organization, admin)
+insert into person (id, email, name, subject_id, password, organization, admin, last_login)
 values (101, 'admin@negotiator.dev', 'admin', '1', '$2a$10$Kk29y.f7WeQeyym0X7YnvewDm3Gm/puTWGFniJvWen93C/f/6Bqey',
-        'BBMRI', true),
+        'BBMRI', true, '2025-07-30'),
        (102, 'directory@negotiator.dev', 'directory', '2',
-        '$2a$10$iHi5bQ8nTRRF1bkiJfygkONgmABH1xNpLy2MZrHdusP.7.Rjpwk.i', 'BBMRI', false),
+        '$2a$10$iHi5bQ8nTRRF1bkiJfygkONgmABH1xNpLy2MZrHdusP.7.Rjpwk.i', 'BBMRI', false, '2025-01-01'),
        (103, 'perun@negotiator.dev', 'perun', '3', '$2a$10$RCBPPd3suXNB4vLSowDdUe5umkyZaDJCt.8DtG3xVidUhxWe2Woci',
-        'BBMRI', false),
+        'BBMRI', false, null),
        (104, 'researcher@negotiator.dev', 'researcher', '4',
-        '$2a$10$6Rc4eC5vo2IMGP0KUgrxIObq2SQoHTBKx8/o/Eyq1PpmzdBtTKj0u', 'BBMRI', false),
-       (105, 'sarah.representative@gmail.com', 'SarahRepr', '5', null, 'Test Biobank', false),
-       (108, 'adam.researcher@gmail.com', 'TheResearcher', '1000@bbmri.eu', null, 'BBMRI', false),
-       (109, 'taylor.biobanker@gmail.com', 'TheBiobanker', '1001@bbmri.eu', null, 'BBMRI', false);
+        '$2a$10$6Rc4eC5vo2IMGP0KUgrxIObq2SQoHTBKx8/o/Eyq1PpmzdBtTKj0u', 'BBMRI', false, '2023-02-15'),
+       (105, 'sarah.representative@gmail.com', 'SarahRepr', '5', null, 'Test Biobank', false, '2025-03-30'),
+       (108, 'adam.researcher@gmail.com', 'TheResearcher', '1000@bbmri.eu', null, 'BBMRI', false, '2025-04-20'),
+       (109, 'taylor.biobanker@gmail.com', 'TheBiobanker', '1001@bbmri.eu', null, 'BBMRI', false, '2025-02-10');
 
 insert into authorities (person_id, authority)
 values (101, 'ADMIN'),  -- still needed for data sources tests

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/UserControllerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/UserControllerTest.java
@@ -121,6 +121,46 @@ public class UserControllerTest {
   }
 
   @Test
+  @WithMockUser(roles = "AUTHORIZATION_MANAGER")
+  void getUsers_validRequest_customPagination() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(LIST_USERS_ENDPOINT).param("page", "1").param("size", "3"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$._embedded.users").isArray())
+        .andExpect(jsonPath("$._embedded.users").isNotEmpty())
+        .andExpect(jsonPath("$.page.totalElements", is(personRepository.findAll().size())))
+        .andExpect(jsonPath("$.page.number", is(1)))
+        .andExpect(jsonPath("$._embedded.users.length()", is(3)));
+  }
+
+  @Test
+  @WithMockUser(roles = "AUTHORIZATION_MANAGER")
+  void getUsers_validRequest_customSorting() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(LIST_USERS_ENDPOINT)
+                .param("sortBy", "name")
+                .param("sortOrder", "ASC"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$._embedded.users").isArray())
+        .andExpect(jsonPath("$._embedded.users").isNotEmpty())
+        .andExpect(jsonPath("$._embedded.users.length()", is(personRepository.findAll().size())))
+        .andExpect(jsonPath("$._embedded.users[0].name", is("admin")));
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(LIST_USERS_ENDPOINT)
+                .param("sortBy", "name")
+                .param("sortOrder", "DESC"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$._embedded.users").isArray())
+        .andExpect(jsonPath("$._embedded.users").isNotEmpty())
+        .andExpect(jsonPath("$._embedded.users.length()", is(personRepository.findAll().size())))
+        .andExpect(jsonPath("$._embedded.users[0].name", is("TheResearcher")));
+  }
+
+  @Test
   @WithMockUser("TheResearcher")
   void getUsers_validRequest_Forbidden() throws Exception {
     mockMvc

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/repository/PersonRepositoryTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/repository/PersonRepositoryTest.java
@@ -137,7 +137,10 @@ public class PersonRepositoryTest {
   @Test
   void findAll_filterWithSpecificationNameContains_ok() {
     Person person = savePerson("a-test", "AAAA");
-    assertTrue(personRepository.findAll(PersonSpecifications.nameContains("AA")).contains(person));
+    assertTrue(
+        personRepository
+            .findAll(PersonSpecifications.propertyContains("name", "AA"))
+            .contains(person));
     assertFalse(
         personRepository
             .findAll(PersonSpecifications.propertyEquals("name", "AA"))

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/PersonServiceImplTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/PersonServiceImplTest.java
@@ -11,7 +11,6 @@ import eu.bbmri_eric.negotiator.user.UserFilterDTO;
 import eu.bbmri_eric.negotiator.user.UserResponseModel;
 import eu.bbmri_eric.negotiator.user.UserSortField;
 import eu.bbmri_eric.negotiator.util.IntegrationTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -39,29 +38,23 @@ public class PersonServiceImplTest {
   }
 
   @Test
-  @Disabled
-  void findAll_invalidSort_throwsWrongSortingPropertyException() {
-    //    assertThrows(WrongSortingPropertyException.class, () -> personService.findAll(0, 1,
-    // "invalid"));
-  }
-
-  @Test
   void findAll_pageAndSorted_ok() {
     Person person =
         personRepository.save(
             Person.builder().subjectId("test-id").name("AAAAA").email("test@test.com").build());
     UserFilterDTO filters =
         UserFilterDTO.builder()
-            .sortBy(UserSortField.name)
+            .sortBy(UserSortField.subjectId)
             .sortOrder(Sort.Direction.DESC)
             .page(0)
             .size(1)
             .build();
+
     assertEquals(
         person.getId().toString(),
         ((Page<UserResponseModel>) personService.findAllByFilters(filters))
             .getContent()
-            .get(0)
+            .getFirst()
             .getId());
   }
 

--- a/frontend/src/components/AdminSettingsFilterSort.vue
+++ b/frontend/src/components/AdminSettingsFilterSort.vue
@@ -60,46 +60,42 @@
     </div>
 
     <div class="row row-cols-auto gap-2 ms-1 my-2">
-      <!-- <div class="col-12 d-flex flex-row align-items-center"> -->
-        <div v-for="field in filtersFields" :key="field.name" class="col mx-1">
-          <TextFilter 
-            v-if="field.type == 'text' || field.type == 'email'"
-            :name="field.name"
-            :label="field.label"
-            :type="field.type"
-            :placeholder="field.placeholder"
-            v-model:value="filtersSortData[field.name]"
-            @input="debouncedFilter">
-          </TextFilter>
-          <OptionsFilter v-else-if="field.type === 'radio' || field.type === 'checkbox'" 
-            :name="field.name"
-            :label="field.label"
-            :type="field.type"
-            :options="field.options"
-            :button-style="filtersSortData[field.name] !== '' 
-              ? returnButtonActiveColor 
-              : returnButtonColor"
-            :label-style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
-            @change="emitFilterSortData"
-            v-model:value="filtersSortData[field.name]"
-          >
-          </OptionsFilter>
-          <DateRangeFilter
-            v-if="field.type == 'date-range'"
-            :name="field.name"
-            :label="field.label"
-            :button-style="filtersSortData[field.name].start !== '' || filtersSortData[field.name].end !== ''
-              ? returnButtonActiveColor
-              : returnButtonColor"
-            :type="field.inputType"
-            v-model:start="filtersSortData[field.name].start"
-            v-model:end="filtersSortData[field.name].end"
-            @startChanged="emitFilterSortData"
-            @endChanged="emitFilterSortData"
-          >
-          </DateRangeFilter>
-        </div>
-      <!-- </div> -->
+      <div v-for="field in filtersFields" :key="field.name" class="col mx-1">
+        <TextFilter 
+          v-if="field.type == 'text' || field.type == 'email'"
+          :name="field.name"
+          :label="field.label"
+          :type="field.type"
+          :placeholder="field.placeholder"
+          v-model:value="filtersSortData[field.name]"
+          @input="debouncedFilter"
+        />
+        <OptionsFilter v-else-if="field.type === 'radio' || field.type === 'checkbox'" 
+          :name="field.name"
+          :label="field.label"
+          :type="field.type"
+          :options="field.options"
+          :button-style="filtersSortData[field.name] !== '' 
+            ? returnButtonActiveColor 
+            : returnButtonColor"
+          :label-style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
+          @change="emitFilterSortData"
+          v-model:value="filtersSortData[field.name]"
+        />
+        <DateRangeFilter
+          v-if="field.type == 'date-range'"
+          :name="field.name"
+          :label="field.label"
+          :button-style="filtersSortData[field.name].start !== '' || filtersSortData[field.name].end !== ''
+            ? returnButtonActiveColor
+            : returnButtonColor"
+          :type="field.inputType"
+          v-model:start="filtersSortData[field.name].start"
+          v-model:end="filtersSortData[field.name].end"
+          @startChanged="emitFilterSortData"
+          @endChanged="emitFilterSortData"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/frontend/src/components/AdminSettingsFilterSort.vue
+++ b/frontend/src/components/AdminSettingsFilterSort.vue
@@ -2,17 +2,17 @@
   <div class="container">
     <div class="row gap-2 my-2 mx-auto mx-md-0 mb-3">
       <div class="col d-flex flex-row">
-        <div v-if="sortByFields" class="dropdown">
+        <div class="dropdown">
           <button
             class="btn dropdown-toggle custom-button-hover mx-2"
-            :style="filtersSortData.sortBy !== '' ? returnButtonActiveColor : returnButtonColor"
+            :style="filtersSortData.sortBy !== '' ? buttonActiveStyle : buttonStyle"
             :class="filtersSortData.sortBy !== '' ? 'show' : ''"
             type="button"
             data-bs-toggle="dropdown"
             data-bs-auto-close="outside"
             aria-expanded="false"
           >
-            Sort by
+            Sort by {{ currentSortBy }}
           </button>
           <ul class="dropdown-menu" aria-labelledby="dropdownSortingButton" role="menu">
             <div v-for="(sort, index) in sortByFields.fields" :key="index" class="form-check mx-2 my-2">
@@ -37,9 +37,8 @@
         </div>
 
         <button
-          v-if="sortByFields"
           class="btn custom-button-hover"
-          :style="returnButtonColor"
+          :style="buttonStyle"
           type="button"
           @click="changeSortDirection()"
         >
@@ -49,7 +48,7 @@
 
         <button
           type="button"
-          :style="returnClearButtonColor"
+          :style="clearButtonStyle"
           class="btn custom-button-hover ms-auto"
           @click="clearAllFilters()"
         >
@@ -76,9 +75,9 @@
           :type="field.type"
           :options="field.options"
           :button-style="filtersSortData[field.name] !== '' 
-            ? returnButtonActiveColor 
-            : returnButtonColor"
-          :clear-button-style="returnClearButtonColor"
+            ? buttonActiveStyle 
+            : buttonStyle"
+          :clear-button-style="clearButtonStyle"
           :label-style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
           @change="emitFilterSortData"
           v-model:value="filtersSortData[field.name]"
@@ -88,8 +87,8 @@
           :name="field.name"
           :label="field.label"
           :button-style="filtersSortData[field.name].start !== '' || filtersSortData[field.name].end !== ''
-            ? returnButtonActiveColor
-            : returnButtonColor"
+            ? buttonActiveStyle
+            : buttonStyle"
           :type="field.inputType"
           v-model:start="filtersSortData[field.name].start"
           v-model:end="filtersSortData[field.name].end"
@@ -104,7 +103,6 @@
 <script setup>
 import { computed } from 'vue'
 import { ROLES } from '@/config/consts'
-// import { useRouter } from 'vue-router'
 import { useUiConfiguration } from '../store/uiConfiguration.js'
 import TextFilter from './filters/TextFilter.vue'
 import OptionsFilter from './filters/OptionsFilter.vue'
@@ -112,7 +110,6 @@ import DateRangeFilter from './filters/DateRangeFilter.vue'
 
 const filtersSortData = defineModel('filtersSortData')
 const uiConfigurationStore = useUiConfiguration()
-// const router = useRouter()
 
 const props = defineProps({
   filtersFields: {
@@ -138,7 +135,7 @@ const uiConfiguration = computed(() => {
   return uiConfigurationStore.uiConfiguration?.filtersSort
 })
 
-const returnButtonActiveColor = computed(() => {
+const buttonActiveStyle = computed(() => {
   return {
     'border-color': uiConfiguration.value?.filtersSortButtonColor,
     '--hovercolor': uiConfiguration.value?.filtersSortButtonColor,
@@ -147,7 +144,7 @@ const returnButtonActiveColor = computed(() => {
   }
 })
 
-const returnButtonColor = computed(() => {
+const buttonStyle = computed(() => {
   return {
     'border-color': uiConfiguration.value?.filtersSortButtonColor,
     '--hovercolor': uiConfiguration.value?.filtersSortButtonColor,
@@ -156,13 +153,21 @@ const returnButtonColor = computed(() => {
   }
 })
 
-const returnClearButtonColor = computed(() => {
+const clearButtonStyle = computed(() => {
   return {
     'border-color': uiConfiguration.value?.filtersSortClearButtonColor,
     '--hovercolor': uiConfiguration.value?.filtersSortClearButtonColor,
     'background-color': '#FFFFFF',
     color: uiConfiguration.value?.filtersSortClearButtonColor,
   }
+})
+
+const currentSortBy = computed(() => {
+  const field = props.sortByFields.fields.find(field => field.value === filtersSortData.value.sortBy)
+  if (field) {
+    return field.label 
+  }
+  return '' 
 })
 
 // Simple debounce function to replace lodash
@@ -187,7 +192,6 @@ function emitFilterSortData() {
 }
 
 function changeSortDirection() {
-  console.log(filtersSortData.value.sortOrder)
   if (filtersSortData.value.sortOrder === 'DESC') {
     filtersSortData.value.sortOrder = 'ASC'
   } else {
@@ -204,10 +208,11 @@ function clearAllFilters() {
   filtersSortData.value.sortOrder = props.sortByFields.defaultOrder
 
   emit('filtersSortData', filtersSortData.value)
-  // router.push({ query: {} })
 }
 
 function isChecked(value) {
+  console.log(value)
+  console.log(filtersSortData.value.sortBy === value)
   return filtersSortData.value.sortBy === value
 }
 </script>

--- a/frontend/src/components/AdminSettingsFilterSort.vue
+++ b/frontend/src/components/AdminSettingsFilterSort.vue
@@ -78,6 +78,7 @@
           :button-style="filtersSortData[field.name] !== '' 
             ? returnButtonActiveColor 
             : returnButtonColor"
+          :clear-button-style="returnClearButtonColor"
           :label-style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
           @change="emitFilterSortData"
           v-model:value="filtersSortData[field.name]"

--- a/frontend/src/components/EmailNotificationsSection.vue
+++ b/frontend/src/components/EmailNotificationsSection.vue
@@ -9,8 +9,7 @@
       :filters-fields="filtersFields"
       :user-role="ROLES.ADMINISTRATOR"
       @filters-sort-data="applyFilters"
-    >
-    </AdminSettingsFilterSort>
+    />
 
     <!-- Loading indicator -->
     <div v-if="loading" class="text-center py-4">
@@ -117,8 +116,11 @@ const emit = defineEmits(['view-email'])
 
 const emailStore = useEmailStore()
 
+const emails = ref([])
+const loading = ref(false)
+
 const sortByFields = ref({
-  defaultField: 'sentAt',
+  defaultField: 'address',
   defaultOrder: 'DESC',
   fields: [
     { value: 'address', label: 'Email Address' },
@@ -140,9 +142,6 @@ const filtersSortData = ref({
   sortBy: sortByFields.value.defaultField,
   sortOrder: sortByFields.value.defaultOrder
 })
-
-const emails = ref([])
-const loading = ref(false)
 
 const pagination = ref({
   number: 0,
@@ -280,7 +279,6 @@ const formatForJavaLocalDateTime = (date) => {
 }
 
 onMounted(() => {
-  console.log("mounting emails")
   // Set sentAfter to yesterday at 00:00 by default
   filtersSortData.value.sentAt.start = getYesterdayStartForInput()
   // Set sentBefore to current date/time by default

--- a/frontend/src/components/EmailNotificationsSection.vue
+++ b/frontend/src/components/EmailNotificationsSection.vue
@@ -3,14 +3,14 @@
     <h3 class="mb-4">Email Notifications</h3>
 
     <!-- Filters -->
-    <UserFilterSort
+    <AdminSettingsFilterSort
       v-model:filtersSortData="filtersSortData"
       :sort-by-fields="sortByFields"
       :filters-fields="filtersFields"
       :user-role="ROLES.ADMINISTRATOR"
       @filters-sort-data="applyFilters"
     >
-    </UserFilterSort>
+    </AdminSettingsFilterSort>
 
     <!-- Loading indicator -->
     <div v-if="loading" class="text-center py-4">
@@ -109,8 +109,8 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useEmailStore } from '@/store/emails.js'
-import UserFilterSort from './UserFilterSort.vue'
 import { ROLES } from '@/config/consts'
+import AdminSettingsFilterSort from './AdminSettingsFilterSort.vue'
 
 
 const emit = defineEmits(['view-email'])

--- a/frontend/src/components/UserFilterSort.vue
+++ b/frontend/src/components/UserFilterSort.vue
@@ -1,52 +1,66 @@
 <template>
-  <div class="container d-flex flex-row flex-wrap justify-content-between">
-    <div class="d-flex flex-row gap-2 my-2 mx-auto mx-md-0">
-      <div>
+  <div class="container">
+    <div class="row gap-2 my-2 mx-auto mx-md-0 mb-3">
+      <div class="col d-flex flex-row">
+        <div class="dropdown">
+          <button
+            class="btn dropdown-toggle custom-button-hover mx-2"
+            :style="filtersSortData.sortBy !== '' ? returnButtonActiveColor : returnButtonColor"
+            :class="filtersSortData.sortBy !== '' ? 'show' : ''"
+            type="button"
+            data-bs-toggle="dropdown"
+            data-bs-auto-close="outside"
+            aria-expanded="false"
+          >
+            Sort by
+          </button>
+          <ul class="dropdown-menu" aria-labelledby="dropdownSortingButton" role="menu">
+            <div v-for="(sort, index) in sortByFields.fields" :key="index" class="form-check mx-2 my-2">
+              <input
+                :id="index"
+                v-model="filtersSortData.sortBy"
+                class="form-check-input"
+                type="radio"
+                name="sort"
+                :value="sort.value"
+                :checked="isChecked(sort.value)"
+                @change="emitFilterSortData"
+              />
+              <label
+                class="form-check-label"
+                :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
+              >
+                {{ sort.label }}
+              </label>
+            </div>
+          </ul>
+        </div>
+
         <button
-          class="btn dropdown-toggle custom-button-hover"
-          :style="filtersSortData.sortBy !== '' ? returnButtonActiveColor : returnButtonColor"
-          :class="filtersSortData.sortBy !== '' ? 'show' : ''"
+          class="btn custom-button-hover"
+          :style="returnButtonColor"
           type="button"
-          data-bs-toggle="dropdown"
-          data-bs-auto-close="outside"
-          aria-expanded="false"
+          @click="changeSortDirection()"
         >
-          Sort by
+          <i v-if="filtersSortData.sortOrder === 'DESC'" class="bi bi-sort-down" />
+          <i v-if="filtersSortData.sortOrder === 'ASC'" class="bi bi-sort-up" />
         </button>
-        <ul class="dropdown-menu" aria-labelledby="dropdownSortingButton" role="menu">
-          <div v-for="(sort, index) in sortByFields.fields" :key="index" class="form-check mx-2 my-2">
-            <input
-              :id="index"
-              v-model="filtersSortData.sortBy"
-              class="form-check-input"
-              type="radio"
-              name="sort"
-              :value="sort.value"
-              :checked="isChecked(sort.value)"
-              @change="emitFilterSortData"
-            />
-            <label
-              class="form-check-label"
-              :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
-            >
-              {{ sort.label }}
-            </label>
-          </div>
-        </ul>
+
+        <button
+          type="button"
+          :style="returnClearButtonColor"
+          class="btn custom-button-hover ms-auto"
+          @click="clearAllFilters()"
+        >
+          <i class="bi bi-x-circle" />
+          Clear all filters
+        </button>
       </div>
+    </div>
 
-      <button
-        class="btn custom-button-hover"
-        :style="returnButtonColor"
-        type="button"
-        @click="changeSortDirection()"
-      >
-        <i v-if="filtersSortData.sortOrder === 'DESC'" class="bi bi-sort-down" />
-        <i v-if="filtersSortData.sortOrder === 'ASC'" class="bi bi-sort-up" />
-      </button>
-
-      <div class="d-flex flex-row align-items-center ms-1">
-        <div v-for="field in filtersFields" :key="field.name" class="mx-1">
+    <div class="row row-cols-auto gap-2 ms-1 my-2">
+      <!-- <div class="col-12 d-flex flex-row align-items-center"> -->
+        <div v-for="field in filtersFields" :key="field.name" class="col mx-1">
           <TextFilter 
             v-if="field.type == 'text' || field.type == 'email'"
             :name="field.name"
@@ -60,7 +74,9 @@
             :label="field.label"
             :type="field.type"
             :options="field.options"
-            :button-style="returnButtonActiveColor"
+            :button-style="filtersSortData[field.name] !== '' 
+              ? returnButtonActiveColor 
+              : returnButtonColor"
             :label-style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
             @change="emitFilterSortData"
             v-model:value="filtersSortData[field.name]"
@@ -80,18 +96,7 @@
           >
           </DateRangeFilter>
         </div>
-      </div>
-    </div>
-    <div class="my-2 ms-auto">
-      <button
-        type="button"
-        :style="returnClearButtonColor"
-        class="btn custom-button-hover"
-        @click="clearAllFilters()"
-      >
-        <i class="bi bi-x-circle" />
-        Clear all filters
-      </button>
+      <!-- </div> -->
     </div>
   </div>
 </template>
@@ -183,10 +188,11 @@ function emitFilterSortData() {
 }
 
 function changeSortDirection() {
-  if (filtersSortData.value.sortDirection === 'DESC') {
-    filtersSortData.value.sortDirection = 'ASC'
+  console.log(filtersSortData.value.sortOrder)
+  if (filtersSortData.value.sortOrder === 'DESC') {
+    filtersSortData.value.sortOrder = 'ASC'
   } else {
-    filtersSortData.value.sortDirection = 'DESC'
+    filtersSortData.value.sortOrder = 'DESC'
   }
   emit('filtersSortData', filtersSortData.value)
 }
@@ -196,7 +202,7 @@ function clearAllFilters() {
     filtersSortData.value[filterDefinition.name] = filterDefinition.default
   }) 
   filtersSortData.value.sortBy = props.sortByFields.defaultField
-  filtersSortData.value.sortDirection = props.sortByFields.defaultDirection
+  filtersSortData.value.sortOrder = props.sortByFields.defaultOrder
 
   emit('filtersSortData', filtersSortData.value)
   // router.push({ query: {} })

--- a/frontend/src/components/UserFilterSort.vue
+++ b/frontend/src/components/UserFilterSort.vue
@@ -66,6 +66,19 @@
             v-model:value="filtersSortData[field.name]"
           >
           </OptionsFilter>
+          <DateRangeFilter
+            v-if="field.type == 'date-range'"
+            :name="field.name"
+            :label="field.label"
+            :button-style="filtersSortData[field.name].start !== '' || filtersSortData[field.name].end !== ''
+              ? returnButtonActiveColor
+              : returnButtonColor"
+            v-model:start="filtersSortData[field.name].start"
+            v-model:end="filtersSortData[field.name].end"
+            @startChanged="emitFilterSortData"
+            @endChanged="emitFilterSortData"
+          >
+          </DateRangeFilter>
         </div>
       </div>
     </div>
@@ -90,6 +103,7 @@ import { ROLES } from '@/config/consts'
 import { useUiConfiguration } from '../store/uiConfiguration.js'
 import TextFilter from './filters/TextFilter.vue'
 import OptionsFilter from './filters/OptionsFilter.vue'
+import DateRangeFilter from './filters/DateRangeFilter.vue'
 
 const filtersSortData = defineModel('filtersSortData')
 const uiConfigurationStore = useUiConfiguration()

--- a/frontend/src/components/UserFilterSort.vue
+++ b/frontend/src/components/UserFilterSort.vue
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="row gap-2 my-2 mx-auto mx-md-0 mb-3">
       <div class="col d-flex flex-row">
-        <div class="dropdown">
+        <div v-if="sortByFields" class="dropdown">
           <button
             class="btn dropdown-toggle custom-button-hover mx-2"
             :style="filtersSortData.sortBy !== '' ? returnButtonActiveColor : returnButtonColor"
@@ -37,6 +37,7 @@
         </div>
 
         <button
+          v-if="sortByFields"
           class="btn custom-button-hover"
           :style="returnButtonColor"
           type="button"
@@ -66,6 +67,7 @@
             :name="field.name"
             :label="field.label"
             :type="field.type"
+            :placeholder="field.placeholder"
             v-model:value="filtersSortData[field.name]"
             @input="debouncedFilter">
           </TextFilter>
@@ -89,6 +91,7 @@
             :button-style="filtersSortData[field.name].start !== '' || filtersSortData[field.name].end !== ''
               ? returnButtonActiveColor
               : returnButtonColor"
+            :type="field.inputType"
             v-model:start="filtersSortData[field.name].start"
             v-model:end="filtersSortData[field.name].end"
             @startChanged="emitFilterSortData"
@@ -128,8 +131,7 @@ const props = defineProps({
   },
   sortByFields: {
     type: Array,
-    required: true,
-    default: () => []
+    required: false
   }
 })
 

--- a/frontend/src/components/UserFilterSort.vue
+++ b/frontend/src/components/UserFilterSort.vue
@@ -3,7 +3,7 @@
     <div class="d-flex flex-row gap-2 my-2 mx-auto mx-md-0">
       <div class="sort-by">
         <button
-          class="btn btn-sm dropdown-toggle custom-button-hover"
+          class="btn dropdown-toggle custom-button-hover"
           :style="filtersSortData.sortBy !== '' ? returnButtonActiveColor : returnButtonColor"
           :class="filtersSortData.sortBy !== '' ? 'show' : ''"
           type="button"
@@ -14,7 +14,7 @@
           Sort by
         </button>
         <ul class="dropdown-menu" aria-labelledby="dropdownSortingButton" role="menu">
-          <div v-for="(sort, index) in sortByFields" :key="index" class="form-check mx-2 my-2">
+          <div v-for="(sort, index) in sortByFields.fields" :key="index" class="form-check mx-2 my-2">
             <input
               :id="index"
               v-model="filtersSortData.sortBy"
@@ -36,140 +36,39 @@
       </div>
 
       <button
-        class="btn btn-sm custom-button-hover"
+        class="btn custom-button-hover"
         :style="returnButtonColor"
         type="button"
         @click="changeSortDirection()"
       >
-        <i v-if="filtersSortData.sortDirection === 'DESC'" class="bi bi-sort-down" />
-        <i v-if="filtersSortData.sortDirection === 'ASC'" class="bi bi-sort-up" />
+        <i v-if="filtersSortData.sortOrder === 'DESC'" class="bi bi-sort-down" />
+        <i v-if="filtersSortData.sortOrder === 'ASC'" class="bi bi-sort-up" />
       </button>
 
-      <!-- <div id="v-step-3" class="filter-by-status">
-        <button
-          class="btn btn-sm dropdown-toggle custom-button-hover"
-          :style="filtersSortData.status.length > 0 ? returnButtonActiveColor : returnButtonColor"
-          :class="filtersSortData.status.length > 0 ? 'show' : ''"
-          type="button"
-          data-bs-toggle="dropdown"
-          data-bs-auto-close="outside"
-          aria-expanded="false"
-        >
-          Filter by status
-        </button>
-        <ul class="dropdown-menu" aria-labelledby="dropdownSortingButton" role="menu">
-          <div v-for="(status, index) in filtersStatus" :key="index" class="form-check mx-2 my-2">
+      <div class="row align-items-center ms-1">
+        <input
+          type="hidden"
+          class="form-control"
+        />
+        <div v-for="field in filtersFields" :key="field.name" class="col-auto">
+          <div class="input-group">
+            <span class="input-group-text">{{ field.label  }}</span>
             <input
-              v-model="filtersSortData.status"
-              class="form-check-input"
-              type="checkbox"
-              :value="status.value"
-              @change="emitFilterSortData"
+              :id="field.name"
+              v-model="filtersSortData[field.name]"
+              type="text"
+              class="form-control"
+              @input="debouncedFilter"
             />
-            <label
-              class="form-check-label"
-              :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
-            >
-              {{ status.label }}
-            </label>
           </div>
-        </ul>
+        </div>
       </div>
-
-      <div id="v-step-4" class="filter-by-org" v-if="filterOrganizations.length > 0">
-        <button
-          class="btn btn-sm dropdown-toggle custom-button-hover"
-          :style="
-            filtersSortData.organizations.length > 0 ? returnButtonActiveColor : returnButtonColor
-          "
-          :class="filtersSortData.organizations.length > 0 ? 'show' : ''"
-          type="button"
-          data-bs-toggle="dropdown"
-          data-bs-auto-close="outside"
-          aria-expanded="false"
-        >
-          Filter by Organization
-        </button>
-        <ul class="dropdown-menu" aria-labelledby="dropdownSortingButton" role="menu">
-          <div
-            v-for="(org, index) in filterOrganizations"
-            :key="index"
-            class="form-check mx-2 my-2"
-          >
-            <input
-              v-model="filtersSortData.organizations"
-              class="form-check-input"
-              type="checkbox"
-              :value="org.id"
-              @change="emitFilterSortData"
-            />
-            <label
-              class="form-check-label"
-              :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
-            >
-              {{ org.name }}
-            </label>
-          </div>
-        </ul>
-      </div>
-
-      <div class="filter-by-date">
-        <button
-          class="btn btn-sm dropdown-toggle custom-button-hover"
-          :style="
-            filtersSortData.dateStart !== '' || filtersSortData.dateEnd !== ''
-              ? returnButtonActiveColor
-              : returnButtonColor
-          "
-          :class="
-            filtersSortData.dateStart !== '' || filtersSortData.dateEnd !== ''
-              ? 'btn-primary show'
-              : ''
-          "
-          type="button"
-          data-bs-toggle="dropdown"
-          data-bs-auto-close="outside"
-          aria-expanded="false"
-        >
-          Filter by date
-        </button>
-        <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
-          <div
-            class="mx-2 my-2 dropdown-contents"
-            :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
-          >
-            <div class="d-flex align-items-center mb-2">
-              <label class="pe-2 w-25" for="startDate">Start:</label>
-              <input
-                id="startDate"
-                v-model="filtersSortData.dateStart"
-                class="form-control form-control-sm"
-                :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
-                type="date"
-                @input="emitFilterSortData"
-              />
-            </div>
-            <div class="d-flex align-items-center">
-              <label for="endDate" class="pe-3 w-25">End:</label>
-              <input
-                id="endDate"
-                v-model="filtersSortData.dateEnd"
-                class="form-control form-control-sm"
-                :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
-                type="date"
-                @input="emitFilterSortData"
-              />
-            </div>
-          </div>
-        </ul>
-      </div> -->
     </div>
-
     <div class="my-2 ms-auto">
       <button
         type="button"
         :style="returnClearButtonColor"
-        class="btn btn-sm custom-button-hover"
+        class="btn custom-button-hover"
         @click="clearAllFilters()"
       >
         <i class="bi bi-x-circle" />
@@ -182,22 +81,19 @@
 <script setup>
 import { computed } from 'vue'
 import { ROLES } from '@/config/consts'
-import { useRouter } from 'vue-router'
+// import { useRouter } from 'vue-router'
 import { useUiConfiguration } from '../store/uiConfiguration.js'
 
 const filtersSortData = defineModel('filtersSortData')
 const uiConfigurationStore = useUiConfiguration()
-const router = useRouter()
+// const router = useRouter()
 
-defineProps({
-  // filtersStatus: {
-  //   type: Array,
-  //   default: () => [],
-  // },
-  // filterOrganizations: {
-  //   type: Array,
-  //   default: () => [],
-  // },
+const props = defineProps({
+  filtersFields: {
+    type: Array,
+    required: true,
+    default: () => []
+  },
   userRole: {
     type: String,
     required: true,
@@ -225,6 +121,7 @@ const returnButtonActiveColor = computed(() => {
     color: '#FFFFFF',
   }
 })
+
 const returnButtonColor = computed(() => {
   return {
     'border-color': uiConfiguration.value?.filtersSortButtonColor,
@@ -243,6 +140,23 @@ const returnClearButtonColor = computed(() => {
   }
 })
 
+// Simple debounce function to replace lodash
+const debounce = (func, wait) => {
+  let timeout
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout)
+      func(...args)
+    }
+    clearTimeout(timeout)
+    timeout = setTimeout(later, wait)
+  }
+}
+
+const debouncedFilter = debounce(() => {
+  emitFilterSortData()
+}, 500)
+
 function emitFilterSortData() {
   emit('filtersSortData', filtersSortData.value)
 }
@@ -257,15 +171,14 @@ function changeSortDirection() {
 }
 
 function clearAllFilters() {
-  // filtersSortData.value.status = []
-  // filtersSortData.value.organizations = []
-  // filtersSortData.value.dateStart = ''
-  // filtersSortData.value.dateEnd = ''
-  filtersSortData.value.sortBy = 'creationDate'
-  filtersSortData.value.sortDirection = 'DESC'
+  props.filtersFields.forEach((filterDefinition) => {
+    filtersSortData.value[filterDefinition.name] = filterDefinition.default
+  }) 
+  filtersSortData.value.sortBy = props.sortByFields.defaultField
+  filtersSortData.value.sortDirection = props.sortByFields.defaultDirection
 
   emit('filtersSortData', filtersSortData.value)
-  router.push({ query: {} })
+  // router.push({ query: {} })
 }
 
 function isChecked(value) {

--- a/frontend/src/components/UserFilterSort.vue
+++ b/frontend/src/components/UserFilterSort.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container d-flex flex-row flex-wrap justify-content-between">
     <div class="d-flex flex-row gap-2 my-2 mx-auto mx-md-0">
-      <div class="sort-by">
+      <div>
         <button
           class="btn dropdown-toggle custom-button-hover"
           :style="filtersSortData.sortBy !== '' ? returnButtonActiveColor : returnButtonColor"
@@ -45,22 +45,27 @@
         <i v-if="filtersSortData.sortOrder === 'ASC'" class="bi bi-sort-up" />
       </button>
 
-      <div class="row align-items-center ms-1">
-        <input
-          type="hidden"
-          class="form-control"
-        />
-        <div v-for="field in filtersFields" :key="field.name" class="col-auto">
-          <div class="input-group">
-            <span class="input-group-text">{{ field.label  }}</span>
-            <input
-              :id="field.name"
-              v-model="filtersSortData[field.name]"
-              type="text"
-              class="form-control"
-              @input="debouncedFilter"
-            />
-          </div>
+      <div class="d-flex flex-row align-items-center ms-1">
+        <div v-for="field in filtersFields" :key="field.name" class="mx-1">
+          <TextFilter 
+            v-if="field.type == 'text' || field.type == 'email'"
+            :name="field.name"
+            :label="field.label"
+            :type="field.type"
+            v-model:value="filtersSortData[field.name]"
+            @input="debouncedFilter">
+          </TextFilter>
+          <OptionsFilter v-else-if="field.type === 'radio' || field.type === 'checkbox'" 
+            :name="field.name"
+            :label="field.label"
+            :type="field.type"
+            :options="field.options"
+            :button-style="returnButtonActiveColor"
+            :label-style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
+            @change="emitFilterSortData"
+            v-model:value="filtersSortData[field.name]"
+          >
+          </OptionsFilter>
         </div>
       </div>
     </div>
@@ -83,6 +88,8 @@ import { computed } from 'vue'
 import { ROLES } from '@/config/consts'
 // import { useRouter } from 'vue-router'
 import { useUiConfiguration } from '../store/uiConfiguration.js'
+import TextFilter from './filters/TextFilter.vue'
+import OptionsFilter from './filters/OptionsFilter.vue'
 
 const filtersSortData = defineModel('filtersSortData')
 const uiConfigurationStore = useUiConfiguration()

--- a/frontend/src/components/UserFilterSort.vue
+++ b/frontend/src/components/UserFilterSort.vue
@@ -1,0 +1,282 @@
+<template>
+  <div class="container d-flex flex-row flex-wrap justify-content-between">
+    <div class="d-flex flex-row gap-2 my-2 mx-auto mx-md-0">
+      <div class="sort-by">
+        <button
+          class="btn btn-sm dropdown-toggle custom-button-hover"
+          :style="filtersSortData.sortBy !== '' ? returnButtonActiveColor : returnButtonColor"
+          :class="filtersSortData.sortBy !== '' ? 'show' : ''"
+          type="button"
+          data-bs-toggle="dropdown"
+          data-bs-auto-close="outside"
+          aria-expanded="false"
+        >
+          Sort by
+        </button>
+        <ul class="dropdown-menu" aria-labelledby="dropdownSortingButton" role="menu">
+          <div v-for="(sort, index) in sortByFields" :key="index" class="form-check mx-2 my-2">
+            <input
+              :id="index"
+              v-model="filtersSortData.sortBy"
+              class="form-check-input"
+              type="radio"
+              name="sort"
+              :value="sort.value"
+              :checked="isChecked(sort.value)"
+              @change="emitFilterSortData"
+            />
+            <label
+              class="form-check-label"
+              :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
+            >
+              {{ sort.label }}
+            </label>
+          </div>
+        </ul>
+      </div>
+
+      <button
+        class="btn btn-sm custom-button-hover"
+        :style="returnButtonColor"
+        type="button"
+        @click="changeSortDirection()"
+      >
+        <i v-if="filtersSortData.sortDirection === 'DESC'" class="bi bi-sort-down" />
+        <i v-if="filtersSortData.sortDirection === 'ASC'" class="bi bi-sort-up" />
+      </button>
+
+      <!-- <div id="v-step-3" class="filter-by-status">
+        <button
+          class="btn btn-sm dropdown-toggle custom-button-hover"
+          :style="filtersSortData.status.length > 0 ? returnButtonActiveColor : returnButtonColor"
+          :class="filtersSortData.status.length > 0 ? 'show' : ''"
+          type="button"
+          data-bs-toggle="dropdown"
+          data-bs-auto-close="outside"
+          aria-expanded="false"
+        >
+          Filter by status
+        </button>
+        <ul class="dropdown-menu" aria-labelledby="dropdownSortingButton" role="menu">
+          <div v-for="(status, index) in filtersStatus" :key="index" class="form-check mx-2 my-2">
+            <input
+              v-model="filtersSortData.status"
+              class="form-check-input"
+              type="checkbox"
+              :value="status.value"
+              @change="emitFilterSortData"
+            />
+            <label
+              class="form-check-label"
+              :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
+            >
+              {{ status.label }}
+            </label>
+          </div>
+        </ul>
+      </div>
+
+      <div id="v-step-4" class="filter-by-org" v-if="filterOrganizations.length > 0">
+        <button
+          class="btn btn-sm dropdown-toggle custom-button-hover"
+          :style="
+            filtersSortData.organizations.length > 0 ? returnButtonActiveColor : returnButtonColor
+          "
+          :class="filtersSortData.organizations.length > 0 ? 'show' : ''"
+          type="button"
+          data-bs-toggle="dropdown"
+          data-bs-auto-close="outside"
+          aria-expanded="false"
+        >
+          Filter by Organization
+        </button>
+        <ul class="dropdown-menu" aria-labelledby="dropdownSortingButton" role="menu">
+          <div
+            v-for="(org, index) in filterOrganizations"
+            :key="index"
+            class="form-check mx-2 my-2"
+          >
+            <input
+              v-model="filtersSortData.organizations"
+              class="form-check-input"
+              type="checkbox"
+              :value="org.id"
+              @change="emitFilterSortData"
+            />
+            <label
+              class="form-check-label"
+              :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
+            >
+              {{ org.name }}
+            </label>
+          </div>
+        </ul>
+      </div>
+
+      <div class="filter-by-date">
+        <button
+          class="btn btn-sm dropdown-toggle custom-button-hover"
+          :style="
+            filtersSortData.dateStart !== '' || filtersSortData.dateEnd !== ''
+              ? returnButtonActiveColor
+              : returnButtonColor
+          "
+          :class="
+            filtersSortData.dateStart !== '' || filtersSortData.dateEnd !== ''
+              ? 'btn-primary show'
+              : ''
+          "
+          type="button"
+          data-bs-toggle="dropdown"
+          data-bs-auto-close="outside"
+          aria-expanded="false"
+        >
+          Filter by date
+        </button>
+        <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+          <div
+            class="mx-2 my-2 dropdown-contents"
+            :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
+          >
+            <div class="d-flex align-items-center mb-2">
+              <label class="pe-2 w-25" for="startDate">Start:</label>
+              <input
+                id="startDate"
+                v-model="filtersSortData.dateStart"
+                class="form-control form-control-sm"
+                :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
+                type="date"
+                @input="emitFilterSortData"
+              />
+            </div>
+            <div class="d-flex align-items-center">
+              <label for="endDate" class="pe-3 w-25">End:</label>
+              <input
+                id="endDate"
+                v-model="filtersSortData.dateEnd"
+                class="form-control form-control-sm"
+                :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
+                type="date"
+                @input="emitFilterSortData"
+              />
+            </div>
+          </div>
+        </ul>
+      </div> -->
+    </div>
+
+    <div class="my-2 ms-auto">
+      <button
+        type="button"
+        :style="returnClearButtonColor"
+        class="btn btn-sm custom-button-hover"
+        @click="clearAllFilters()"
+      >
+        <i class="bi bi-x-circle" />
+        Clear all filters
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { ROLES } from '@/config/consts'
+import { useRouter } from 'vue-router'
+import { useUiConfiguration } from '../store/uiConfiguration.js'
+
+const filtersSortData = defineModel('filtersSortData')
+const uiConfigurationStore = useUiConfiguration()
+const router = useRouter()
+
+defineProps({
+  // filtersStatus: {
+  //   type: Array,
+  //   default: () => [],
+  // },
+  // filterOrganizations: {
+  //   type: Array,
+  //   default: () => [],
+  // },
+  userRole: {
+    type: String,
+    required: true,
+    validator: (prop) =>
+      [ROLES.RESEARCHER, ROLES.REPRESENTATIVE, ROLES.ADMINISTRATOR].includes(prop),
+  },
+  sortByFields: {
+    type: Array,
+    required: true,
+    default: () => []
+  }
+})
+
+const emit = defineEmits(['filtersSortData'])
+
+const uiConfiguration = computed(() => {
+  return uiConfigurationStore.uiConfiguration?.filtersSort
+})
+
+const returnButtonActiveColor = computed(() => {
+  return {
+    'border-color': uiConfiguration.value?.filtersSortButtonColor,
+    '--hovercolor': uiConfiguration.value?.filtersSortButtonColor,
+    'background-color': uiConfiguration.value?.filtersSortButtonColor,
+    color: '#FFFFFF',
+  }
+})
+const returnButtonColor = computed(() => {
+  return {
+    'border-color': uiConfiguration.value?.filtersSortButtonColor,
+    '--hovercolor': uiConfiguration.value?.filtersSortButtonColor,
+    'background-color': '#FFFFFF',
+    color: uiConfiguration.value?.filtersSortButtonColor,
+  }
+})
+
+const returnClearButtonColor = computed(() => {
+  return {
+    'border-color': uiConfiguration.value?.filtersSortClearButtonColor,
+    '--hovercolor': uiConfiguration.value?.filtersSortClearButtonColor,
+    'background-color': '#FFFFFF',
+    color: uiConfiguration.value?.filtersSortClearButtonColor,
+  }
+})
+
+function emitFilterSortData() {
+  emit('filtersSortData', filtersSortData.value)
+}
+
+function changeSortDirection() {
+  if (filtersSortData.value.sortDirection === 'DESC') {
+    filtersSortData.value.sortDirection = 'ASC'
+  } else {
+    filtersSortData.value.sortDirection = 'DESC'
+  }
+  emit('filtersSortData', filtersSortData.value)
+}
+
+function clearAllFilters() {
+  // filtersSortData.value.status = []
+  // filtersSortData.value.organizations = []
+  // filtersSortData.value.dateStart = ''
+  // filtersSortData.value.dateEnd = ''
+  filtersSortData.value.sortBy = 'creationDate'
+  filtersSortData.value.sortDirection = 'DESC'
+
+  emit('filtersSortData', filtersSortData.value)
+  router.push({ query: {} })
+}
+
+function isChecked(value) {
+  return filtersSortData.value.sortBy === value
+}
+</script>
+
+<style scoped>
+.custom-button-hover:hover {
+  background-color: var(--hovercolor) !important;
+  color: #ffffff !important;
+  border-color: var(--hovercolor) !important;
+}
+</style>

--- a/frontend/src/components/UserListSection.vue
+++ b/frontend/src/components/UserListSection.vue
@@ -96,7 +96,8 @@ const filtersFields = ref([
   { name: 'name', label: 'Name', type: 'text', default: '' },
   { name: 'email', label: 'Email', type: 'email', default: '' },
   { name: 'subjectId', label: 'Subject ID', type: 'text', default: '' },
-  { name: 'isAdmin', label: 'Is Admin', type: 'radio', options: [{ value: true, label: "True" }, { value: false, label: "False" }], default: ''}
+  { name: 'isAdmin', label: 'Is Admin', type: 'radio', options: [{ value: true, label: "True" }, { value: false, label: "False" }], default: ''},
+  { name: 'lastLogin', label: 'Last Login', type: 'date-range', default: { start: '', end: '' } }
 ])
 
 const filtersSortData = ref({
@@ -104,6 +105,10 @@ const filtersSortData = ref({
   email: '',
   subjectId: '',
   isAdmin: '',
+  lastLogin: {
+    start: '', 
+    end: ''
+  },
   sortBy: 'lastLogin',
   sortOrder: 'DESC',
 })
@@ -146,11 +151,23 @@ const resetPage = () => {
 
 const fetchUsers = async () => {
   isLoading.value = true
+
+  const data = {
+    name: filtersSortData.value.name,
+    email: filtersSortData.value.email,
+    subjectId: filtersSortData.value.subjectId,
+    isAdmin: filtersSortData.value.isAdmin,
+    lastLoginAfter: filtersSortData.value.lastLogin.start,
+    lastLoginBefore: filtersSortData.value.lastLogin.end,
+    sortBy: 'lastLogin',
+    sortOrder: 'DESC',
+  }
+
   try {
     const { users: usersData, totalUsers: totalCount } = await adminStore.retrieveUsers(
       currentPage.value - 1,
       pageSize.value,
-      filtersSortData.value
+      data
     )
     users.value = usersData || []
     totalUsers.value = totalCount || 0

--- a/frontend/src/components/UserListSection.vue
+++ b/frontend/src/components/UserListSection.vue
@@ -3,7 +3,7 @@
     <div class="d-flex justify-content-between align-items-center mb-3">
       <h2 class="text-left">Users</h2>
     </div>
-    <UserFilterSort
+    <AdminSettingsFilterSort
       v-model:filtersSortData="filtersSortData"
       :filters-fields="filtersFields"
       :sort-by-fields="sortByFields"
@@ -70,7 +70,7 @@
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
 import { useAdminStore } from '@/store/admin.js'
-import UserFilterSort from './UserFilterSort.vue'
+import AdminSettingsFilterSort from './AdminSettingsFilterSort.vue'
 import { ROLES } from '@/config/consts'
 
 const users = ref([])

--- a/frontend/src/components/UserListSection.vue
+++ b/frontend/src/components/UserListSection.vue
@@ -93,9 +93,9 @@ const sortByFields = ref({
 )
 
 const filtersFields = ref([
-  { name: 'name', label: 'Name', type: 'text', default: '' },
-  { name: 'email', label: 'Email', type: 'email', default: '' },
-  { name: 'subjectId', label: 'Subject ID', type: 'text', default: '' },
+  { name: 'name', label: 'Name', type: 'text', default: '', placeholder: 'Enter the Name' },
+  { name: 'email', label: 'Email', type: 'email', default: '', placeholder: 'Enter the Email' },
+  { name: 'subjectId', label: 'Subject ID', type: 'text', default: '', placeholder: 'Enter the Subject Id'},
   { name: 'isAdmin', label: 'Is Admin', type: 'radio', options: [{ value: true, label: "True" }, { value: false, label: "False" }], default: ''},
   { name: 'lastLogin', label: 'Last Login', type: 'date-range', default: { start: '', end: '' } }
 ])
@@ -109,8 +109,8 @@ const filtersSortData = ref({
     start: '', 
     end: ''
   },
-  sortBy: 'lastLogin',
-  sortOrder: 'DESC',
+  sortBy: sortByFields.value.defaultField,
+  sortOrder: sortByFields.value.defaultOrder,
 })
 
 

--- a/frontend/src/components/UserListSection.vue
+++ b/frontend/src/components/UserListSection.vue
@@ -5,6 +5,12 @@
     </div>
     <div v-if="users.length === 0 && !isLoading" class="text-muted mb-3">No users found.</div>
     <div v-else class="table-container">
+      <UserFilterSort
+        v-model:filtersSortData="userFiltersSortData"
+        :sort-by-fields="userSortByFields"
+        :user-role="ROLES.ADMINISTRATOR"
+        @filters-sort-data="fetchUsers"
+      />
       <table class="table table-hover">
         <thead>
           <tr>
@@ -63,6 +69,8 @@
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
 import { useAdminStore } from '@/store/admin.js'
+import UserFilterSort from './UserFilterSort.vue'
+import { ROLES } from '@/config/consts'
 
 const users = ref([])
 const currentPage = ref(1)
@@ -70,6 +78,20 @@ const pageSize = ref(10)
 const totalUsers = ref(0)
 const isLoading = ref(false)
 const adminStore = useAdminStore()
+
+const userSortByFields = ref([
+  { value: "id", label: 'ID' },
+  { value: 'subjectId', label: 'Subject Id' },
+  { value: 'name', label: 'Name' },
+  { value: 'email', label: 'Email' },
+  { value: 'lastLogin', label: 'Last Login' }
+])
+
+const userFiltersSortData = ref({
+  sortBy: 'lastLogin',
+  sortDirection: 'DESC',
+})
+
 
 const formatDate = (dateString) => {
   if (!dateString) return '-'
@@ -112,6 +134,8 @@ const fetchUsers = async () => {
     const { users: usersData, totalUsers: totalCount } = await adminStore.retrieveUsers(
       currentPage.value - 1,
       pageSize.value,
+      userFiltersSortData.value.sortBy,
+      userFiltersSortData.value.sortDirection,
     )
     users.value = usersData || []
     totalUsers.value = totalCount || 0

--- a/frontend/src/components/UserListSection.vue
+++ b/frontend/src/components/UserListSection.vue
@@ -3,14 +3,15 @@
     <div class="d-flex justify-content-between align-items-center mb-3">
       <h2 class="text-left">Users</h2>
     </div>
+    <UserFilterSort
+      v-model:filtersSortData="filtersSortData"
+      :filters-fields="filtersFields"
+      :sort-by-fields="sortByFields"
+      :user-role="ROLES.ADMINISTRATOR"
+      @filters-sort-data="fetchUsers"
+    />
     <div v-if="users.length === 0 && !isLoading" class="text-muted mb-3">No users found.</div>
     <div v-else class="table-container">
-      <UserFilterSort
-        v-model:filtersSortData="userFiltersSortData"
-        :sort-by-fields="userSortByFields"
-        :user-role="ROLES.ADMINISTRATOR"
-        @filters-sort-data="fetchUsers"
-      />
       <table class="table table-hover">
         <thead>
           <tr>
@@ -79,17 +80,29 @@ const totalUsers = ref(0)
 const isLoading = ref(false)
 const adminStore = useAdminStore()
 
-const userSortByFields = ref([
-  { value: "id", label: 'ID' },
-  { value: 'subjectId', label: 'Subject Id' },
-  { value: 'name', label: 'Name' },
-  { value: 'email', label: 'Email' },
-  { value: 'lastLogin', label: 'Last Login' }
+const sortByFields = ref({
+  defaultField: 'lastLogin',
+  defaultDirection: 'DESC',
+  fields: [
+    { value: 'id', label: 'ID' },
+    { value: 'name', label: 'Name' },
+    { value: 'email', label: 'Email' },
+    { value: 'subjectId', label: 'Subject Id' },
+    { value: 'lastLogin', label: 'Last Login' }
+  ]}
+)
+
+const filtersFields = ref([
+  { name: 'name', label: 'Name', type: 'text', default: '' },
+  { name: 'email', label: 'Email', type: 'text', default: '' },
+  { name: 'subjectId', label: 'Subject ID', type: 'text', default: '' },
 ])
 
-const userFiltersSortData = ref({
+const filtersSortData = ref({
+  name: '',
+  email: '',
   sortBy: 'lastLogin',
-  sortDirection: 'DESC',
+  sortOrder: 'DESC',
 })
 
 
@@ -134,8 +147,7 @@ const fetchUsers = async () => {
     const { users: usersData, totalUsers: totalCount } = await adminStore.retrieveUsers(
       currentPage.value - 1,
       pageSize.value,
-      userFiltersSortData.value.sortBy,
-      userFiltersSortData.value.sortDirection,
+      filtersSortData.value
     )
     users.value = usersData || []
     totalUsers.value = totalCount || 0

--- a/frontend/src/components/UserListSection.vue
+++ b/frontend/src/components/UserListSection.vue
@@ -94,13 +94,16 @@ const sortByFields = ref({
 
 const filtersFields = ref([
   { name: 'name', label: 'Name', type: 'text', default: '' },
-  { name: 'email', label: 'Email', type: 'text', default: '' },
+  { name: 'email', label: 'Email', type: 'email', default: '' },
   { name: 'subjectId', label: 'Subject ID', type: 'text', default: '' },
+  { name: 'isAdmin', label: 'Is Admin', type: 'radio', options: [{ value: true, label: "True" }, { value: false, label: "False" }], default: ''}
 ])
 
 const filtersSortData = ref({
   name: '',
   email: '',
+  subjectId: '',
+  isAdmin: '',
   sortBy: 'lastLogin',
   sortOrder: 'DESC',
 })

--- a/frontend/src/components/UserListSection.vue
+++ b/frontend/src/components/UserListSection.vue
@@ -82,7 +82,7 @@ const adminStore = useAdminStore()
 
 const sortByFields = ref({
   defaultField: 'lastLogin',
-  defaultDirection: 'DESC',
+  defaultOrder: 'DESC',
   fields: [
     { value: 'id', label: 'ID' },
     { value: 'name', label: 'Name' },
@@ -159,8 +159,8 @@ const fetchUsers = async () => {
     isAdmin: filtersSortData.value.isAdmin,
     lastLoginAfter: filtersSortData.value.lastLogin.start,
     lastLoginBefore: filtersSortData.value.lastLogin.end,
-    sortBy: 'lastLogin',
-    sortOrder: 'DESC',
+    sortBy: filtersSortData.value.sortBy,
+    sortOrder: filtersSortData.value.sortOrder,
   }
 
   try {

--- a/frontend/src/components/filters/DateRangeFilter.vue
+++ b/frontend/src/components/filters/DateRangeFilter.vue
@@ -16,34 +16,27 @@
         class="mx-2 my-2 dropdown-contents"
         :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
       >
-        <div class="d-flex align-items-center mb-2">
-          <label class="pe-2 w-25" for="startDate">Start:</label>
-          <input
-            id="startDate"
-            v-model="start"
-            class="form-control form-control-sm"
-            :style="inputStyle"
-            :type="type"
-            @input="emitStartChange"
-          />
-        </div>
-        <div class="d-flex align-items-center">
-          <label for="endDate" class="pe-3 w-25">End:</label>
-          <input
-            id="endDate"
-            v-model="end"
-            class="form-control form-control-sm"
-            :style="inputStyle"
-            :type="type"
-            @input="emitEndChange"
-          />
-        </div>
+        <TextFilter
+          v-model:value="start"
+          label="Start"
+          :type="type"
+          @input="emitStartChange"
+        />
+        <TextFilter
+          v-model:value="end"
+          class="mt-2"
+          label="End"
+          :type="type"
+          @input="emitEndChange"
+        />
       </div>
     </ul>
   </div>
 </template>
 
 <script setup>
+import TextFilter from './TextFilter.vue'
+
 const start = defineModel("start")
 const end = defineModel("end")
 

--- a/frontend/src/components/filters/DateRangeFilter.vue
+++ b/frontend/src/components/filters/DateRangeFilter.vue
@@ -1,0 +1,95 @@
+<template>
+  <div>
+    <button
+      class="btn dropdown-toggle custom-button-hover"
+      :style="buttonStyle"
+      :class="buttonClass"
+      type="button"
+      data-bs-toggle="dropdown"
+      data-bs-auto-close="outside"
+      aria-expanded="false"
+    >
+      {{ label }}
+    </button>
+    <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+      <div
+        class="mx-2 my-2 dropdown-contents"
+        :style="{ color: uiConfiguration?.filtersSortDropdownTextColor }"
+      >
+        <div class="d-flex align-items-center mb-2">
+          <label class="pe-2 w-25" for="startDate">Start:</label>
+          <input
+            id="startDate"
+            v-model="start"
+            class="form-control form-control-sm"
+            :style="inputStyle"
+            type="date"
+            @input="emitStartChange"
+          />
+        </div>
+        <div class="d-flex align-items-center">
+          <label for="endDate" class="pe-3 w-25">End:</label>
+          <input
+            id="endDate"
+            v-model="end"
+            class="form-control form-control-sm"
+            :style="inputStyle"
+            type="date"
+            @input="emitEndChange"
+          />
+        </div>
+      </div>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+const start = defineModel("start")
+const end = defineModel("end")
+
+const emit = defineEmits(["startChanged", "endChanged"])
+
+defineProps({
+  name: {
+    type: String,
+    required: true
+  },
+  label: {
+    type: String,
+    required: true
+  },
+  buttonStyle: {
+    type: Object,
+    required: false,
+    default: () => {}
+  },
+  buttonClass: {
+    type: Object,
+    required: false,
+    default: () => {}
+  },
+  inputStyle: {
+    type: Object,
+    required: false,
+    default: () => {}
+  },
+  
+})
+
+function emitStartChange() {
+  emit('startChanged', start.value)
+}
+
+function emitEndChange() {
+  emit('endChanged', end.value)
+}
+
+</script>
+
+<style scoped>
+.custom-button-hover:hover {
+  background-color: var(--hovercolor) !important;
+  color: #ffffff !important;
+  border-color: var(--hovercolor) !important;
+}
+</style>

--- a/frontend/src/components/filters/DateRangeFilter.vue
+++ b/frontend/src/components/filters/DateRangeFilter.vue
@@ -29,6 +29,15 @@
           :type="type"
           @input="emitEndChange"
         />
+        <button
+          type="button"
+          :style="clearButtonStyle"
+          class="btn custom-button-hover mt-2"
+          @click="clearAll"
+        >
+          <i class="bi bi-x-circle" />
+          Clear
+        </button>
       </div>
     </ul>
   </div>
@@ -72,7 +81,16 @@ defineProps({
     required: false,
     default: () => {}
   },
-  
+  clearButtonStyle: {
+    type: Object,
+    required: false,
+    default: () => ({
+      'border-color': '#dc3545',
+      '--hovercolor': '#dc3545',
+      'background-color': '#FFFFFF',
+      'color': '#dc3545'
+    })
+  }
 })
 
 function emitStartChange() {
@@ -80,6 +98,13 @@ function emitStartChange() {
 }
 
 function emitEndChange() {
+  emit('endChanged', end.value)
+}
+
+function clearAll() {
+  start.value = ''
+  end.value = ''
+  emit('startChanged', start.value)
   emit('endChanged', end.value)
 }
 

--- a/frontend/src/components/filters/DateRangeFilter.vue
+++ b/frontend/src/components/filters/DateRangeFilter.vue
@@ -23,7 +23,7 @@
             v-model="start"
             class="form-control form-control-sm"
             :style="inputStyle"
-            type="date"
+            :type="type"
             @input="emitStartChange"
           />
         </div>
@@ -34,7 +34,7 @@
             v-model="end"
             class="form-control form-control-sm"
             :style="inputStyle"
-            type="date"
+            :type="type"
             @input="emitEndChange"
           />
         </div>
@@ -57,6 +57,12 @@ defineProps({
   label: {
     type: String,
     required: true
+  },
+  type: {
+    type: String,
+    required: false,
+    default: 'date',
+    validator: (prop) => ['date', 'datetime', 'date-local', 'datetime-local'].includes(prop)
   },
   buttonStyle: {
     type: Object,

--- a/frontend/src/components/filters/OptionsFilter.vue
+++ b/frontend/src/components/filters/OptionsFilter.vue
@@ -1,0 +1,83 @@
+<template>
+  <div>
+    <button
+      class="btn dropdown-toggle custom-button-hover show"
+      :style="buttonStyle"
+      type="button"
+      data-bs-toggle="dropdown"
+      data-bs-auto-close="outside"
+      aria-expanded="false"
+    >
+      {{ label }}
+    </button>
+    <ul class="dropdown-menu" aria-labelledby="dropdownSortingButton" role="menu">
+      <div v-for="(option, index) in options" :key="index" class="form-check mx-2 my-2">
+        <input
+          v-model="value"
+          class="form-check-input"
+          :type="type"
+          :value="option.value"
+          @change="emitChange"
+        />
+        <label
+          class="form-check-label"
+          :style=labelStyle
+        >
+          {{ option.label }}
+        </label>
+      </div>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+
+const value = defineModel("value")
+
+const emit = defineEmits(["change"])
+
+defineProps({
+  name: {
+    type: String,
+    required: true
+  },
+  label: {
+    type: String,
+    required: true
+  },
+  type: {
+    type: String,
+    required: false,
+    default: 'checkbox',
+    validator: (prop) => ['checkbox', 'radio'].includes(prop)
+  },
+  options: {
+    type: Array,
+    required: true,
+    default: () => []
+  },
+  buttonStyle: {
+    type: Object,
+    required: false,
+    default: () => {}
+  },
+  labelStyle: {
+    type: Object,
+    required: false,
+    default: () => {}
+  }  
+})
+
+function emitChange() {
+  emit('change', value.value)
+}
+
+</script>
+
+<style scoped>
+.custom-button-hover:hover {
+  background-color: var(--hovercolor) !important;
+  color: #ffffff !important;
+  border-color: var(--hovercolor) !important;
+}
+</style>

--- a/frontend/src/components/filters/OptionsFilter.vue
+++ b/frontend/src/components/filters/OptionsFilter.vue
@@ -26,15 +26,15 @@
           {{ option.label }}
         </label>
       </div>
-       <button
-          type="button"
-          :style="clearButtonStyle"
-          class="btn custom-button-hover mt-1 ms-2"
-          @click="clearValue"
-        >
-          <i class="bi bi-x-circle" />
-          Clear
-        </button>
+      <button
+        type="button"
+        :style="clearButtonStyle"
+        class="btn custom-button-hover mt-1 ms-2"
+        @click="clearValue"
+      >
+        <i class="bi bi-x-circle" />
+        Clear
+      </button>
     </ul>    
   </div>
 </template>

--- a/frontend/src/components/filters/OptionsFilter.vue
+++ b/frontend/src/components/filters/OptionsFilter.vue
@@ -26,7 +26,16 @@
           {{ option.label }}
         </label>
       </div>
-    </ul>
+       <button
+          type="button"
+          :style="clearButtonStyle"
+          class="btn custom-button-hover mt-1 ms-2"
+          @click="clearValue"
+        >
+          <i class="bi bi-x-circle" />
+          Clear
+        </button>
+    </ul>    
   </div>
 </template>
 
@@ -65,11 +74,26 @@ defineProps({
     type: Object,
     required: false,
     default: () => {}
-  }  
+  },
+  clearButtonStyle: {
+    type: Object,
+    required: false,
+    default: () => ({
+      'border-color': '#dc3545',
+      '--hovercolor': '#dc3545',
+      'background-color': '#FFFFFF',
+      'color': '#dc3545'
+    })
+  }
 })
 
 function emitChange() {
   emit('change', value.value)
+}
+
+function clearValue() {
+  value.value = ''
+  emitChange()
 }
 
 </script>

--- a/frontend/src/components/filters/TextFilter.vue
+++ b/frontend/src/components/filters/TextFilter.vue
@@ -5,6 +5,7 @@
       :id="name"
       v-model="value"
       :type="type"
+      :placeholder="placeholder"
       class="form-control"
       @input="emitInput"
     />
@@ -31,6 +32,11 @@ defineProps({
     required: false,
     default: 'text',
     validator: (prop) => ['test', 'email'].includes(prop)
+  },
+  placeholder: {
+    type: String,
+    required: false,
+    default: ''
   }
 })
 

--- a/frontend/src/components/filters/TextFilter.vue
+++ b/frontend/src/components/filters/TextFilter.vue
@@ -9,6 +9,9 @@
       class="form-control"
       @input="emitInput"
     />
+    <button class="input-group-text" @click="resetValue">
+        <i class="bi bi-x"></i>
+    </button>
   </div>
 </template>
 
@@ -44,4 +47,13 @@ function emitInput() {
   emit('input', value.value)
 }
 
+function resetValue() {
+  value.value = ''
+  emitInput()
+}
+
 </script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/components/filters/TextFilter.vue
+++ b/frontend/src/components/filters/TextFilter.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="input-group">
+    <span class="input-group-text">{{ label }}</span>
+    <input
+      :id="name"
+      v-model="value"
+      :type="type"
+      class="form-control"
+      @input="emitInput"
+    />
+  </div>
+</template>
+
+<script setup>
+
+const value = defineModel("value")
+
+const emit = defineEmits(["input"])
+
+defineProps({
+  name: {
+    type: String,
+    required: true
+  },
+  label: {
+    type: String,
+    required: true
+  },
+  type: {
+    type: String,
+    required: false,
+    default: 'text',
+    validator: (prop) => ['test', 'email'].includes(prop)
+  }
+})
+
+function emitInput() {
+  emit('input', value.value)
+}
+
+</script>

--- a/frontend/src/store/admin.js
+++ b/frontend/src/store/admin.js
@@ -131,6 +131,7 @@ export const useAdminStore = defineStore('admin', () => {
   function retrieveUsers(page = 0, size = 10, filtersSortData) {
     // add filtersSortData in case they are valued
     const params = Object.fromEntries(
+      // eslint-disable-next-line
       Object.entries(filtersSortData).filter(([_, value]) => value !== '')
     );
     params.page = page

--- a/frontend/src/store/admin.js
+++ b/frontend/src/store/admin.js
@@ -128,16 +128,17 @@ export const useAdminStore = defineStore('admin', () => {
       .then((response) => response.data)
   }
 
-  function retrieveUsers(page = 0, size = 10, sortBy = 'lastLogin', sortOrder = 'DESC') {
+  function retrieveUsers(page = 0, size = 10, filtersSortData) {
+    // add filtersSortData in case they are valued
+    const params = Object.fromEntries(
+      Object.entries(filtersSortData).filter(([_, value]) => value !== '')
+    );
+    params.page = page
+    params.size = size
     return axios
       .get(`${apiPaths.BASE_API_PATH}/users`, {
         headers: getBearerHeaders(),
-        params: {
-          page, // Pass the current page (0-indexed)
-          size, // Pass the number of users per page
-          sortBy,
-          sortOrder,
-        },
+        params: params,
       })
       .then((response) => {
         return {

--- a/frontend/src/store/admin.js
+++ b/frontend/src/store/admin.js
@@ -143,7 +143,7 @@ export const useAdminStore = defineStore('admin', () => {
       })
       .then((response) => {
         return {
-          users: response.data._embedded.users, // List of users for the current page
+          users: response.data.page.totalElements > 0 ? response.data._embedded.users : [],
           totalUsers: response.data.page.totalElements, // Total count of users (for pagination)
         }
       })

--- a/frontend/src/store/admin.js
+++ b/frontend/src/store/admin.js
@@ -128,13 +128,15 @@ export const useAdminStore = defineStore('admin', () => {
       .then((response) => response.data)
   }
 
-  function retrieveUsers(page = 0, size = 10) {
+  function retrieveUsers(page = 0, size = 10, sortBy = 'lastLogin', sortOrder = 'DESC') {
     return axios
       .get(`${apiPaths.BASE_API_PATH}/users`, {
         headers: getBearerHeaders(),
         params: {
           page, // Pass the current page (0-indexed)
           size, // Pass the number of users per page
+          sortBy,
+          sortOrder,
         },
       })
       .then((response) => {

--- a/frontend/src/views/AdminSettingsPage.vue
+++ b/frontend/src/views/AdminSettingsPage.vue
@@ -20,7 +20,7 @@
     <hr />
     <EmailNotificationsSection @view-email="viewEmailDetails" />
     <hr />
-    <UserListSection :users="users" />
+    <UserListSection />
   </div>
   <LoadingIndicator v-else />
   <WebhookModal
@@ -68,7 +68,6 @@ const notifications = useNotificationsStore()
 const resourceAllEvents = ref({})
 const infoRequirements = ref([])
 const accessForms = ref([])
-const users = ref([])
 const isLoading = ref(true)
 const editModal = ref(undefined)
 const selectedWebhook = ref({})
@@ -86,7 +85,6 @@ onMounted(async () => {
     resourceAllEvents.value = await adminStore.retrieveResourceAllEvents()
     infoRequirements.value = await adminStore.retrieveInfoRequirements()
     accessForms.value = await formsStore.retrieveAllAccessForms()
-    users.value = (await adminStore.retrieveUsers()) || []
     const freshWebhooks = await adminStore.retrieveWebhooks()
     webhooks.value = freshWebhooks || []
   } catch (error) {


### PR DESCRIPTION
## Negotiator pull request:

### Description:

The PR implements search functionalities for `/users` endpoint as required by #825 
It contains some changes both in the backend and in the frontend:
Backend:
  - Add `PersonSpecificatons` for dynamically handling filtering for users, similarly to NegotiationSpecifications 
  - Add filtering by `name`, `subjectId`, `email`, `isAdmin` and `lastLogin` (before and after)
  - Add sorting by `id`, `subjectId`, `email`, `isAdmin` and `lastLogin`

Frontend:
 - Add filters for users in the `AdminSettings` page
 - Add a reusable component `AdminSettingsFilterSort` to create filters from some configuration properties.
 - Add components for three filter types: `TextFilter` (text, email), `OptionsFilter` (radio, checkbox), `DateRange` (with start and end range). All components can be configured with some properties
 - Refactor `EmailNotifications` filtering to use AdminSettingsFilterSort

**NB: the NegotiationList page may be refactored to use the AdminSettingsFilterSort**

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
