### PR TITLE
feat: add app startup message

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/ApplicationReadyListener.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/ApplicationReadyListener.java
@@ -1,12 +1,11 @@
 package eu.bbmri_eric.negotiator.common;
 
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.ApplicationListener;
-import org.springframework.stereotype.Component;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
 
 /** Start up message printer */
 @Component


### PR DESCRIPTION
## Negotiator pull request:

### Description:

This pull request introduces a new startup message printer for the application, which displays a randomized, colorized message when the app is ready. This enhancement improves the developer experience by providing a fun and clear indication of successful startup.

Application startup experience:

* Added `ApplicationReadyListener` class to print a random, colorized startup message when the application is ready (`backend/src/main/java/eu/bbmri_eric/negotiator/common/ApplicationReadyListener.java`).

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
