### PR TITLE
bug: PDF generation does not maintain the order of elements

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/pdf/NegotiationPdfServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/pdf/NegotiationPdfServiceImpl.java
@@ -152,7 +152,9 @@ public class NegotiationPdfServiceImpl implements NegotiationPdfService {
   private Context createContext(Negotiation negotiation, boolean includeAttachments) {
     Map<String, Object> payload = new LinkedHashMap<>();
     try {
-      payload = this.objectMapper.readValue(negotiation.getPayload(), new TypeReference<>() {});
+      payload =
+          this.objectMapper.readValue(
+              negotiation.getPayload(), new TypeReference<LinkedHashMap<String, Object>>() {});
     } catch (JsonProcessingException e) {
       log.error("Error processing negotiation payload: " + e.getMessage());
     }


### PR DESCRIPTION
…ments for PDF generation.

## Negotiator pull request:

### Description:

Replaced HashMap with LinkedHashMap to maintain the order of elements for PDF generation.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [X] I have performed a self-review of my code
- [X] I have made my code as simple as possible
- [X] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [X] I have removed all commented code
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [X] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
