### PR TITLE
fix: fixed user search in representative assignment modal

### DIFF
--- a/frontend/src/components/form-components/AccessFormOverview.vue
+++ b/frontend/src/components/form-components/AccessFormOverview.vue
@@ -4,9 +4,9 @@
       <h2 class="mb-3">Overview</h2>
       <p class="mb-0 mb-5">
         Upon confirmation, your request will undergo content review. Our reviewers may contact you
-        via email for further details. Upon approval, the respective organizations you wish to contact
-        will be notified of your request. Please click 'Submit request' and then 'Confirm' to
-        proceed.
+        via email for further details. Upon approval, the respective organizations you wish to
+        contact will be notified of your request. Please click 'Submit request' and then 'Confirm'
+        to proceed.
       </p>
     </div>
 

--- a/frontend/src/components/modals/ResourceRepresentativesModal.vue
+++ b/frontend/src/components/modals/ResourceRepresentativesModal.vue
@@ -218,7 +218,7 @@ const notifications = useNotificationsStore()
 
 const representativesFilterData = ref({
   name: '',
-  email: ''
+  email: '',
 })
 const searchResults = ref([])
 const isLoading = ref(false)
@@ -246,19 +246,22 @@ const handleSearchInput = () => {
 }
 
 const searchUsers = async () => {
-  if (!representativesFilterData.value.name.trim() && !representativesFilterData.value.email.trim()) {
+  if (
+    !representativesFilterData.value.name.trim() &&
+    !representativesFilterData.value.email.trim()
+  ) {
     searchResults.value = []
     hasSearched.value = false
   } else {
     isLoading.value = true
     hasSearched.value = true
-  
+
     try {
       const filtersSortData = {
         name: representativesFilterData.value.name,
         email: representativesFilterData.value.email,
       }
-  
+
       const result = await adminStore.retrieveUsers(0, 20, filtersSortData)
       searchResults.value = result.users || []
     } catch {
@@ -268,7 +271,6 @@ const searchUsers = async () => {
       isLoading.value = false
     }
   }
-
 }
 
 const isCurrentRepresentative = (userId) => {


### PR DESCRIPTION
## Negotiator pull request:

### Description:

This PR fixes #938 by splitting the text field that searched for name or email into two search fields "name" and "email" using the filter components used in the aministration's page

### Checklist:

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
