### PR TITLE
fix: resource representatives display name and email

### DIFF
--- a/frontend/src/components/OrganizationListItem.vue
+++ b/frontend/src/components/OrganizationListItem.vue
@@ -167,7 +167,10 @@
                   <span v-else>
                     {{
                       resource.representatives
-                        ?.map((rep) => `${rep.name} (${rep.email})`)
+                        ?.map(
+                          (rep) =>
+                            `${rep.name || 'name not provided'} (${rep.email || 'email not provided'})`,
+                        )
                         .join(', ')
                     }}
                   </span>


### PR DESCRIPTION
## Negotiator pull request:

### Description:

This PR fixes the display of resource representatives by showing both their name and email address instead of just the object representation. The change updates the template to properly format representative information as "Name (email)" for better readability.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
