### PR TITLE
fix: remove notification when fetch system fails, it just annoys users

### DIFF
--- a/frontend/src/store/apiCalls.js
+++ b/frontend/src/store/apiCalls.js
@@ -61,7 +61,6 @@ export const useApiCallsStore = defineStore('apiCalls', () => {
         return response.data
       })
       .catch((error) => {
-        notifications.setNotification('Failed to fetch notifications', 'danger')
         console.error('Error fetching notifications:', error)
         console.error('Request URL:', `${apiPaths.USER_NOTIFICATIONS_PATH}/${userId}/notifications`)
         console.error('Request params:', { page, size })


### PR DESCRIPTION
## Negotiator pull request:

### Description:

This PR removes an error notification when fetching system notifications fails. The change prevents users from being shown a notification about the failure to fetch notifications, while still logging the error to the console for debugging purposes.


### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
