### PR TITLE
fix: formatting of new lines in the negotiation payload view

### DIFF
--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -93,10 +93,8 @@
               <span
                 v-else
                 class="text-break"
-                :style="{ color: uiConfiguration.secondaryTextColor }"
-              >
-                {{ translateTrueFalse(subelement) }}
-              </span>
+                :style="{ color: uiConfiguration.secondaryTextColor, whiteSpace: 'pre-wrap' }"
+              >{{ translateTrueFalse(subelement) }}</span>
             </div>
           </li>
           <li class="list-group-item p-3">


### PR DESCRIPTION
## Negotiator pull request:

### Description:

This pull request makes a small UI improvement to the `NegotiationPage.vue` component by ensuring that text content wraps correctly within its container.

- UI improvement:
  * [`frontend/src/views/NegotiationPage.vue`](diffhunk://#diff-1414f262af4ffbe298e3e0529c05340cc12aeef9c799ec3371de4957fda8c755L96-R97): Added `whiteSpace: 'pre-wrap'` to the style of a `span` element to allow wrapped display of text, improving readability for long or formatted content.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [ ] I have performed a self-review of my code
- [ ] I have made my code as simple as possible
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have removed all commented code
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [ ] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
