### PR TITLE
fix: CORS preflight checks require OPTIONS requests for negotiations endpoint without authentication.

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/configuration/security/HTTPRegistryConfigurer.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/configuration/security/HTTPRegistryConfigurer.java
@@ -33,6 +33,8 @@ public class HTTPRegistryConfigurer {
         .authenticated()
         .requestMatchers(mvc.pattern("/v3/attachments/**"))
         .authenticated()
+        .requestMatchers(mvc.pattern(HttpMethod.OPTIONS, "/v3/negotiations/**"))
+        .permitAll()
         .requestMatchers(mvc.pattern("/v3/negotiations/**"))
         .authenticated()
         .requestMatchers(mvc.pattern("/v3/access-criteria"))


### PR DESCRIPTION
## Negotiator pull request:

### Description:

The CORS preflight OPTIONS request is failing because of the .authenticated() requirement /v3/negotiations/** before it can even get the CORS headers.

OPTIONS requests (CORS preflight) is now allowed without authentication, same as for /v3/negotiations/**.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [X] I have performed a self-review of my code
- [X] I have made my code as simple as possible
- [X] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [X] I have removed all commented code
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [X] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
