### PR TITLE
fix: add old login redirect to home page

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -165,7 +165,7 @@ const router = createRouter({
       component: GuidePage,
       meta: { isPublic: false },
     },
-    // For backwards compatability with Negotiator v2 login path
+    // For backwards compatibility with Negotiator v2 login path
     {
       path: '/login.xhtml',
       redirect: { path: '/', replace: true },


### PR DESCRIPTION
## Negotiator pull request:

### Description:

This pull request introduces a routing update to improve the user experience for legacy or bookmarked URLs. The main change is the addition of a redirect for the `/login.xhtml` path to the home page.

Routing improvements:

* Added a new route in `frontend/src/router/index.js` to redirect `/login.xhtml` requests to the home page (`/`), ensuring users accessing old or external login links are smoothly redirected.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
