### PR TITLE
feat: deliver webhooks based on select application events

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
@@ -43,20 +43,19 @@ class WebhookEventListener {
   }
 
   private void dispatch(WebhookEventEnvelope<?> eventEnvelope) {
-    String payload = serializePayload(eventEnvelope);
+    String payload = serializePayload(eventEnvelope.data());
     if (payload == null) {
       return;
     }
-    webhookService.deliverToActiveWebhooks(payload, eventEnvelope.eventType());
+    webhookService.deliverToActiveWebhooks(
+        payload, eventEnvelope.eventType(), eventEnvelope.occurredAt());
   }
 
-  private String serializePayload(WebhookEventEnvelope<?> eventEnvelope) {
+  private String serializePayload(Object payloadObject) {
     try {
-      return objectMapper.writeValueAsString(eventEnvelope);
+      return objectMapper.writeValueAsString(payloadObject);
     } catch (JsonProcessingException e) {
-      log.error(
-          "Failed to serialize webhook payload for event: %s".formatted(eventEnvelope.eventType()),
-          e);
+      log.error("Failed to serialize webhook payload", e);
       return null;
     }
   }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
@@ -1,0 +1,79 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import eu.bbmri_eric.negotiator.info_submission.InformationSubmissionEvent;
+import eu.bbmri_eric.negotiator.negotiation.NewNegotiationEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationStateChangeEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.ResourceStateChangeEvent;
+import eu.bbmri_eric.negotiator.post.NewPostEvent;
+import java.util.Set;
+import lombok.extern.apachecommons.CommonsLog;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@CommonsLog
+class WebhookEventListener {
+  private static final Set<Class<? extends ApplicationEvent>> DISPATCHED_EVENTS =
+      Set.of(
+          InformationSubmissionEvent.class,
+          NegotiationStateChangeEvent.class,
+          NewNegotiationEvent.class,
+          NewPostEvent.class,
+          ResourceStateChangeEvent.class);
+
+  private final WebhookService webhookService;
+  private final ObjectMapper eventObjectMapper;
+
+  WebhookEventListener(WebhookService webhookService, ObjectMapper objectMapper) {
+    this.webhookService = webhookService;
+    this.eventObjectMapper =
+        objectMapper.copy().addMixIn(ApplicationEvent.class, ApplicationEventMixin.class);
+  }
+
+  @Async
+  @TransactionalEventListener(fallbackExecution = true)
+  void onWebhookEvent(ApplicationEvent event) {
+    if (!DISPATCHED_EVENTS.contains(event.getClass())) {
+      return;
+    }
+    dispatch(event);
+  }
+
+  private void dispatch(ApplicationEvent event) {
+    String payload = serializePayload(event);
+    if (payload == null) {
+      return;
+    }
+
+    webhookService.deliverToActiveWebhooks(payload, eventName(event));
+  }
+
+  private String serializePayload(ApplicationEvent event) {
+    try {
+      return eventObjectMapper.writeValueAsString(event);
+    } catch (JsonProcessingException e) {
+      log.error(
+          "Failed to serialize webhook payload for event: %s"
+              .formatted(event.getClass().getSimpleName()),
+          e);
+      return null;
+    }
+  }
+
+  private String eventName(ApplicationEvent event) {
+    return event.getClass().getSimpleName();
+  }
+
+  private static final class ApplicationEventMixin {
+    @JsonIgnore
+    public Object getSource() {
+      return null;
+    }
+  }
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
@@ -3,7 +3,6 @@ package eu.bbmri_eric.negotiator.webhook;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import eu.bbmri_eric.negotiator.info_submission.InformationSubmissionEvent;
 import eu.bbmri_eric.negotiator.negotiation.NewNegotiationEvent;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationStateChangeEvent;

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
@@ -15,6 +15,11 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+/**
+ * Listens for specific application events and dispatches them to active webhooks. This listener
+ * serializes supported events and delivers them to all configured webhooks using the {@link
+ * WebhookService}. Only events listed in {@code DISPATCHED_EVENTS} are processed.
+ */
 @Component
 @CommonsLog
 class WebhookEventListener {
@@ -35,6 +40,11 @@ class WebhookEventListener {
         objectMapper.copy().addMixIn(ApplicationEvent.class, ApplicationEventMixin.class);
   }
 
+  /**
+   * Handles application events asynchronously and dispatches them to webhooks if supported.
+   *
+   * @param event the application event to process
+   */
   @Async
   @TransactionalEventListener(fallbackExecution = true)
   void onWebhookEvent(ApplicationEvent event) {
@@ -69,6 +79,7 @@ class WebhookEventListener {
     return event.getClass().getSimpleName();
   }
 
+  /** Jackson mixin to ignore the source property when serializing {@link ApplicationEvent}. */
   private static final class ApplicationEventMixin {
     @JsonIgnore
     public Object getSource() {

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookHeaders.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookHeaders.java
@@ -1,0 +1,9 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class WebhookHeaders {
+  public static final String EVENT_TYPE = "X-Webhook-Event-Type";
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookHeaders.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookHeaders.java
@@ -6,4 +6,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WebhookHeaders {
   public static final String EVENT_TYPE = "X-Webhook-Event-Type";
+  public static final String OCCURRED_AT = "X-Webhook-Timestamp";
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookRepository.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookRepository.java
@@ -1,7 +1,10 @@
 package eu.bbmri_eric.negotiator.webhook;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface WebhookRepository extends JpaRepository<Webhook, Long> {}
+public interface WebhookRepository extends JpaRepository<Webhook, Long> {
+  List<Webhook> findByActiveTrue();
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookService.java
@@ -49,4 +49,12 @@ public interface WebhookService {
    * @return a DTO representing the newly created delivery
    */
   DeliveryDTO deliver(String jsonPayload, Long webhookId);
+
+  /**
+   * Creates a new delivery for all active webhooks with an event type header.
+   *
+   * @param jsonPayload the JSON content for the delivery
+   * @param eventType the event type to send as a header
+   */
+  void deliverToActiveWebhooks(String jsonPayload, String eventType);
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookService.java
@@ -1,5 +1,6 @@
 package eu.bbmri_eric.negotiator.webhook;
 
+import java.time.Instant;
 import java.util.List;
 
 public interface WebhookService {
@@ -55,6 +56,7 @@ public interface WebhookService {
    *
    * @param jsonPayload the JSON content for the delivery
    * @param eventType the event type to send as a header
+   * @param occurredAt the event timestamp to send as a header
    */
-  void deliverToActiveWebhooks(String jsonPayload, String eventType);
+  void deliverToActiveWebhooks(String jsonPayload, String eventType, Instant occurredAt);
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationAddedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationAddedWebhookEvent.java
@@ -1,0 +1,8 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+/**
+ * Webhook data payload for a newly created negotiation.
+ *
+ * @param negotiationId identifier of the created negotiation
+ */
+record NegotiationAddedWebhookEvent(String negotiationId) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationInfoUpdatedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationInfoUpdatedWebhookEvent.java
@@ -1,0 +1,8 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+/**
+ * Webhook data payload for an updated information submission in a negotiation.
+ *
+ * @param negotiationId identifier of the affected negotiation
+ */
+record NegotiationInfoUpdatedWebhookEvent(String negotiationId) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationPostAddedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationPostAddedWebhookEvent.java
@@ -1,0 +1,12 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+/**
+ * Webhook data payload for a newly created negotiation post.
+ *
+ * @param postId identifier of the created post
+ * @param negotiationId identifier of the negotiation containing the post
+ * @param userId identifier of the user that created the post
+ * @param organizationId optional identifier of the organization context
+ */
+record NegotiationPostAddedWebhookEvent(
+    String postId, String negotiationId, Long userId, Long organizationId) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationResourceStateUpdatedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationResourceStateUpdatedWebhookEvent.java
@@ -1,0 +1,17 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
+
+/**
+ * Webhook data payload for a resource state transition in a negotiation.
+ *
+ * @param negotiationId identifier of the parent negotiation
+ * @param resourceId identifier of the affected resource
+ * @param fromState previous resource state
+ * @param toState new resource state
+ */
+record NegotiationResourceStateUpdatedWebhookEvent(
+    String negotiationId,
+    String resourceId,
+    NegotiationResourceState fromState,
+    NegotiationResourceState toState) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationResourceUpdatedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationResourceUpdatedWebhookEvent.java
@@ -1,0 +1,8 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+/**
+ * Webhook data payload for newly added resources in a negotiation.
+ *
+ * @param negotiationId identifier of the affected negotiation
+ */
+record NegotiationResourceUpdatedWebhookEvent(String negotiationId) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationStateUpdatedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationStateUpdatedWebhookEvent.java
@@ -1,0 +1,15 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
+
+/**
+ * Webhook data payload for a negotiation state transition.
+ *
+ * @param negotiationId identifier of the affected negotiation
+ * @param changedTo target negotiation state after transition
+ * @param event state-machine event that triggered the transition
+ * @param post optional post payload associated with the transition
+ */
+record NegotiationStateUpdatedWebhookEvent(
+    String negotiationId, NegotiationState changedTo, NegotiationEvent event, String post) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventEnvelope.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventEnvelope.java
@@ -1,0 +1,12 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+import java.time.Instant;
+
+/**
+ * Stable webhook payload envelope.
+ *
+ * @param eventType semantic webhook event name exposed to external consumers
+ * @param occurredAt UTC timestamp describing when the source application event happened
+ * @param data event-specific payload DTO
+ */
+public record WebhookEventEnvelope<T>(String eventType, Instant occurredAt, T data) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapper.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapper.java
@@ -15,9 +15,9 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.stereotype.Component;
 
 /**
- * Maps internal Spring {@link ApplicationEvent} instances to stable webhook event envelopes.
- * The mapper keeps the external webhook contract stable by converting supported application
- * events into dedicated webhook DTO records and semantic event type names.
+ * Maps internal Spring {@link ApplicationEvent} instances to stable webhook event envelopes. The
+ * mapper keeps the external webhook contract stable by converting supported application events into
+ * dedicated webhook DTO records and semantic event type names.
  */
 @Component
 public class WebhookEventMapper {

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapper.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapper.java
@@ -1,0 +1,111 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.bbmri_eric.negotiator.info_submission.InformationSubmissionEvent;
+import eu.bbmri_eric.negotiator.negotiation.NewNegotiationEvent;
+import eu.bbmri_eric.negotiator.negotiation.NewResourcesAddedEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationStateChangeEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.ResourceStateChangeEvent;
+import eu.bbmri_eric.negotiator.post.NewPostEvent;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.stereotype.Component;
+
+/**
+ * Maps internal Spring {@link ApplicationEvent} instances to stable webhook event envelopes.
+ * The mapper keeps the external webhook contract stable by converting supported application
+ * events into dedicated webhook DTO records and semantic event type names.
+ */
+@Component
+public class WebhookEventMapper {
+  private final ObjectMapper objectMapper;
+  private final Map<Class<? extends ApplicationEvent>, WebhookEventDefinition<?, ?>>
+      eventDefinitions;
+
+  /**
+   * Creates a mapper using a dedicated {@link ObjectMapper} copy configured for webhook mapping.
+   *
+   * @param objectMapper the base object mapper to copy and configure
+   */
+  public WebhookEventMapper(ObjectMapper objectMapper) {
+    this.objectMapper =
+        objectMapper.copy().addMixIn(ApplicationEvent.class, ApplicationEventMixin.class);
+    this.eventDefinitions =
+        Map.of(
+            InformationSubmissionEvent.class,
+            WebhookEventDefinition.of(
+                InformationSubmissionEvent.class,
+                NegotiationInfoUpdatedWebhookEvent.class,
+                WebhookEventType.NEGOTIATION_INFO_UPDATED),
+            NegotiationStateChangeEvent.class,
+            WebhookEventDefinition.of(
+                NegotiationStateChangeEvent.class,
+                NegotiationStateUpdatedWebhookEvent.class,
+                WebhookEventType.NEGOTIATION_STATE_UPDATED),
+            NewNegotiationEvent.class,
+            WebhookEventDefinition.of(
+                NewNegotiationEvent.class,
+                NegotiationAddedWebhookEvent.class,
+                WebhookEventType.NEGOTIATION_ADDED),
+            NewResourcesAddedEvent.class,
+            WebhookEventDefinition.of(
+                NewResourcesAddedEvent.class,
+                NegotiationResourceUpdatedWebhookEvent.class,
+                WebhookEventType.NEGOTIATION_RESOURCE_ADDED),
+            NewPostEvent.class,
+            WebhookEventDefinition.of(
+                NewPostEvent.class,
+                NegotiationPostAddedWebhookEvent.class,
+                WebhookEventType.NEGOTIATION_POST_ADDED),
+            ResourceStateChangeEvent.class,
+            WebhookEventDefinition.of(
+                ResourceStateChangeEvent.class,
+                NegotiationResourceStateUpdatedWebhookEvent.class,
+                WebhookEventType.NEGOTIATION_RESOURCE_STATE_UPDATED));
+  }
+
+  /**
+   * Converts a supported application event into a stable webhook envelope.
+   *
+   * @param event the application event to map
+   * @return an envelope when the event type is supported, otherwise an empty optional
+   */
+  public Optional<WebhookEventEnvelope<?>> map(ApplicationEvent event) {
+    WebhookEventDefinition<?, ?> eventDefinition = eventDefinitions.get(event.getClass());
+    if (eventDefinition == null) {
+      return Optional.empty();
+    }
+    return Optional.of(eventDefinition.toEnvelope(event, objectMapper));
+  }
+
+  private record WebhookEventDefinition<S extends ApplicationEvent, T>(
+      Class<S> sourceType, Class<T> dataType, String eventType) {
+
+    private static <S extends ApplicationEvent, T> WebhookEventDefinition<S, T> of(
+        Class<S> sourceType, Class<T> dataType, String eventType) {
+      return new WebhookEventDefinition<>(sourceType, dataType, eventType);
+    }
+
+    private WebhookEventEnvelope<T> toEnvelope(ApplicationEvent sourceEvent, ObjectMapper mapper) {
+      S event = sourceType.cast(sourceEvent);
+      T data = mapper.convertValue(event, dataType);
+      return new WebhookEventEnvelope<>(
+          eventType, Instant.ofEpochMilli(event.getTimestamp()), data);
+    }
+  }
+
+  private static final class ApplicationEventMixin {
+    @JsonIgnore
+    public Object getSource() {
+      return null;
+    }
+
+    @JsonIgnore
+    public long getTimestamp() {
+      return 0L;
+    }
+  }
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventType.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventType.java
@@ -1,0 +1,14 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+/** Defines external webhook event type names. */
+public final class WebhookEventType {
+  public static final String NEGOTIATION_ADDED = "negotiation.added";
+  public static final String NEGOTIATION_STATE_UPDATED = "negotiation.state.updated";
+  public static final String NEGOTIATION_INFO_UPDATED = "negotiation.info.updated";
+  public static final String NEGOTIATION_RESOURCE_ADDED = "negotiation.resource.added";
+  public static final String NEGOTIATION_RESOURCE_STATE_UPDATED =
+      "negotiation.resource.state.updated";
+  public static final String NEGOTIATION_POST_ADDED = "negotiation.post.added";
+
+  private WebhookEventType() {}
+}

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookEventListenerIntegrationTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookEventListenerIntegrationTest.java
@@ -2,6 +2,7 @@ package eu.bbmri_eric.negotiator.integration.service;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -82,12 +83,7 @@ class WebhookEventListenerIntegrationTest {
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE,
                           equalTo(WebhookEventType.NEGOTIATION_STATE_UPDATED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\""
-                                  + WebhookEventType.NEGOTIATION_STATE_UPDATED
-                                  + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"negotiationId\":\"negotiation-1\""))
                       .withRequestBody(containing("\"changedTo\":\"SUBMITTED\""))
                       .withRequestBody(containing("\"event\":\"SUBMIT\""))
@@ -98,12 +94,7 @@ class WebhookEventListenerIntegrationTest {
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE,
                           equalTo(WebhookEventType.NEGOTIATION_STATE_UPDATED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\""
-                                  + WebhookEventType.NEGOTIATION_STATE_UPDATED
-                                  + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"negotiationId\":\"negotiation-1\"")));
               wireMockServer.verify(0, postRequestedFor(urlEqualTo("/negotiation-inactive")));
             });
@@ -137,12 +128,7 @@ class WebhookEventListenerIntegrationTest {
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE,
                           equalTo(WebhookEventType.NEGOTIATION_RESOURCE_STATE_UPDATED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\""
-                                  + WebhookEventType.NEGOTIATION_RESOURCE_STATE_UPDATED
-                                  + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"negotiationId\":\"negotiation-2\""))
                       .withRequestBody(containing("\"resourceId\":\"resource-1\""))
                       .withRequestBody(containing("\"fromState\":\"SUBMITTED\""))
@@ -153,12 +139,7 @@ class WebhookEventListenerIntegrationTest {
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE,
                           equalTo(WebhookEventType.NEGOTIATION_RESOURCE_STATE_UPDATED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\""
-                                  + WebhookEventType.NEGOTIATION_RESOURCE_STATE_UPDATED
-                                  + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"resourceId\":\"resource-1\"")));
               wireMockServer.verify(0, postRequestedFor(urlEqualTo("/resource-inactive")));
             });
@@ -186,10 +167,7 @@ class WebhookEventListenerIntegrationTest {
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE,
                           equalTo(WebhookEventType.NEGOTIATION_POST_ADDED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\"" + WebhookEventType.NEGOTIATION_POST_ADDED + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"postId\":\"post-1\""))
                       .withRequestBody(containing("\"negotiationId\":\"negotiation-1\""))
                       .withRequestBody(containing("\"userId\":10000"))
@@ -200,10 +178,7 @@ class WebhookEventListenerIntegrationTest {
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE,
                           equalTo(WebhookEventType.NEGOTIATION_POST_ADDED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\"" + WebhookEventType.NEGOTIATION_POST_ADDED + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"postId\":\"post-1\"")));
               wireMockServer.verify(0, postRequestedFor(urlEqualTo("/post-inactive")));
             });
@@ -230,20 +205,14 @@ class WebhookEventListenerIntegrationTest {
                   postRequestedFor(urlEqualTo("/new-negotiation-one"))
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE, equalTo(WebhookEventType.NEGOTIATION_ADDED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\"" + WebhookEventType.NEGOTIATION_ADDED + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"negotiationId\":\"negotiation-4\"")));
               wireMockServer.verify(
                   1,
                   postRequestedFor(urlEqualTo("/new-negotiation-two"))
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE, equalTo(WebhookEventType.NEGOTIATION_ADDED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\"" + WebhookEventType.NEGOTIATION_ADDED + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"negotiationId\":\"negotiation-4\"")));
               wireMockServer.verify(0, postRequestedFor(urlEqualTo("/new-negotiation-inactive")));
             });
@@ -271,12 +240,7 @@ class WebhookEventListenerIntegrationTest {
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE,
                           equalTo(WebhookEventType.NEGOTIATION_RESOURCE_ADDED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\""
-                                  + WebhookEventType.NEGOTIATION_RESOURCE_ADDED
-                                  + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"negotiationId\":\"negotiation-6\"")));
               wireMockServer.verify(
                   1,
@@ -284,12 +248,7 @@ class WebhookEventListenerIntegrationTest {
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE,
                           equalTo(WebhookEventType.NEGOTIATION_RESOURCE_ADDED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\""
-                                  + WebhookEventType.NEGOTIATION_RESOURCE_ADDED
-                                  + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"negotiationId\":\"negotiation-6\"")));
               wireMockServer.verify(0, postRequestedFor(urlEqualTo("/resource-added-inactive")));
             });
@@ -317,12 +276,7 @@ class WebhookEventListenerIntegrationTest {
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE,
                           equalTo(WebhookEventType.NEGOTIATION_INFO_UPDATED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\""
-                                  + WebhookEventType.NEGOTIATION_INFO_UPDATED
-                                  + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"negotiationId\":\"negotiation-3\"")));
               wireMockServer.verify(
                   1,
@@ -330,12 +284,7 @@ class WebhookEventListenerIntegrationTest {
                       .withHeader(
                           WebhookHeaders.EVENT_TYPE,
                           equalTo(WebhookEventType.NEGOTIATION_INFO_UPDATED))
-                      .withRequestBody(
-                          containing(
-                              "\"eventType\":\""
-                                  + WebhookEventType.NEGOTIATION_INFO_UPDATED
-                                  + "\""))
-                      .withRequestBody(containing("\"occurredAt\":"))
+                      .withHeader(WebhookHeaders.OCCURRED_AT, matching(".+"))
                       .withRequestBody(containing("\"negotiationId\":\"negotiation-3\"")));
               wireMockServer.verify(0, postRequestedFor(urlEqualTo("/info-inactive")));
             });

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookEventListenerIntegrationTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookEventListenerIntegrationTest.java
@@ -1,0 +1,184 @@
+package eu.bbmri_eric.negotiator.integration.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.awaitility.Awaitility.await;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import eu.bbmri_eric.negotiator.email.EmailService;
+import eu.bbmri_eric.negotiator.info_submission.InformationSubmissionEvent;
+import eu.bbmri_eric.negotiator.integration.api.WebhookSslTestConfig;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationStateChangeEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.ResourceStateChangeListener;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.ResourceStateChangeEvent;
+import eu.bbmri_eric.negotiator.post.NewPostEvent;
+import eu.bbmri_eric.negotiator.util.IntegrationTest;
+import eu.bbmri_eric.negotiator.webhook.Webhook;
+import eu.bbmri_eric.negotiator.webhook.WebhookHeaders;
+import eu.bbmri_eric.negotiator.webhook.WebhookRepository;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@IntegrationTest
+@Import(WebhookSslTestConfig.class)
+class WebhookEventListenerIntegrationTest {
+
+  @RegisterExtension
+  static WireMockExtension wireMockServer =
+      WireMockExtension.newInstance()
+          .options(WireMockConfiguration.options().dynamicPort())
+          .build();
+
+  @Autowired private WebhookRepository webhookRepository;
+
+  @Autowired private ApplicationEventPublisher eventPublisher;
+
+  @MockitoBean private EmailService emailService;
+
+  @MockitoBean private ResourceStateChangeListener resourceStateChangeListener;
+
+  @BeforeEach
+  void setUp() {
+    webhookRepository.deleteAll();
+  }
+
+  @Test
+  void publishNegotiationStateChangeEvent_dispatchesToActiveWebhooks() {
+    String baseUrl = wireMockServer.getRuntimeInfo().getHttpBaseUrl();
+    createWebhook(baseUrl + "/negotiation-one", true);
+    createWebhook(baseUrl + "/negotiation-two", true);
+    createWebhook(baseUrl + "/negotiation-inactive", false);
+
+    wireMockServer.stubFor(post(urlEqualTo("/negotiation-one")));
+    wireMockServer.stubFor(post(urlEqualTo("/negotiation-two")));
+
+    eventPublisher.publishEvent(
+        new NegotiationStateChangeEvent(
+            this, "negotiation-1", NegotiationState.SUBMITTED, NegotiationEvent.SUBMIT, "post"));
+
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              wireMockServer.verify(
+                  1,
+                  postRequestedFor(urlEqualTo("/negotiation-one"))
+                      .withHeader(
+                          WebhookHeaders.EVENT_TYPE, equalTo("NegotiationStateChangeEvent")));
+              wireMockServer.verify(
+                  1,
+                  postRequestedFor(urlEqualTo("/negotiation-two"))
+                      .withHeader(
+                          WebhookHeaders.EVENT_TYPE, equalTo("NegotiationStateChangeEvent")));
+              wireMockServer.verify(0, postRequestedFor(urlEqualTo("/negotiation-inactive")));
+            });
+  }
+
+  @Test
+  void publishResourceStateChangeEvent_dispatchesToActiveWebhooks() {
+    String baseUrl = wireMockServer.getRuntimeInfo().getHttpBaseUrl();
+    createWebhook(baseUrl + "/resource-one", true);
+    createWebhook(baseUrl + "/resource-two", true);
+    createWebhook(baseUrl + "/resource-inactive", false);
+
+    wireMockServer.stubFor(post(urlEqualTo("/resource-one")));
+    wireMockServer.stubFor(post(urlEqualTo("/resource-two")));
+
+    eventPublisher.publishEvent(
+        new ResourceStateChangeEvent(
+            this,
+            "negotiation-2",
+            "resource-1",
+            NegotiationResourceState.SUBMITTED,
+            NegotiationResourceState.RESOURCE_AVAILABLE));
+
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              wireMockServer.verify(
+                  1,
+                  postRequestedFor(urlEqualTo("/resource-one"))
+                      .withHeader(WebhookHeaders.EVENT_TYPE, equalTo("ResourceStateChangeEvent")));
+              wireMockServer.verify(
+                  1,
+                  postRequestedFor(urlEqualTo("/resource-two"))
+                      .withHeader(WebhookHeaders.EVENT_TYPE, equalTo("ResourceStateChangeEvent")));
+              wireMockServer.verify(0, postRequestedFor(urlEqualTo("/resource-inactive")));
+            });
+  }
+
+  @Test
+  void createPost_dispatchesToActiveWebhooks() {
+    String baseUrl = wireMockServer.getRuntimeInfo().getHttpBaseUrl();
+    createWebhook(baseUrl + "/post-one", true);
+    createWebhook(baseUrl + "/post-two", true);
+    createWebhook(baseUrl + "/post-inactive", false);
+
+    wireMockServer.stubFor(post(urlEqualTo("/post-one")));
+    wireMockServer.stubFor(post(urlEqualTo("/post-two")));
+
+    eventPublisher.publishEvent(new NewPostEvent(this, "post-1", "negotiation-1", 10000L, 20000L));
+
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              wireMockServer.verify(
+                  1,
+                  postRequestedFor(urlEqualTo("/post-one"))
+                      .withHeader(WebhookHeaders.EVENT_TYPE, equalTo("NewPostEvent")));
+              wireMockServer.verify(
+                  1,
+                  postRequestedFor(urlEqualTo("/post-two"))
+                      .withHeader(WebhookHeaders.EVENT_TYPE, equalTo("NewPostEvent")));
+              wireMockServer.verify(0, postRequestedFor(urlEqualTo("/post-inactive")));
+            });
+  }
+
+  @Test
+  void publishInformationSubmissionEvent_dispatchesToActiveWebhooks() {
+    String baseUrl = wireMockServer.getRuntimeInfo().getHttpBaseUrl();
+    createWebhook(baseUrl + "/info-one", true);
+    createWebhook(baseUrl + "/info-two", true);
+    createWebhook(baseUrl + "/info-inactive", false);
+
+    wireMockServer.stubFor(post(urlEqualTo("/info-one")));
+    wireMockServer.stubFor(post(urlEqualTo("/info-two")));
+
+    eventPublisher.publishEvent(new InformationSubmissionEvent(this, "negotiation-3"));
+
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              wireMockServer.verify(
+                  1,
+                  postRequestedFor(urlEqualTo("/info-one"))
+                      .withHeader(
+                          WebhookHeaders.EVENT_TYPE, equalTo("InformationSubmissionEvent")));
+              wireMockServer.verify(
+                  1,
+                  postRequestedFor(urlEqualTo("/info-two"))
+                      .withHeader(
+                          WebhookHeaders.EVENT_TYPE, equalTo("InformationSubmissionEvent")));
+              wireMockServer.verify(0, postRequestedFor(urlEqualTo("/info-inactive")));
+            });
+  }
+
+  private Webhook createWebhook(String url, boolean active) {
+    return webhookRepository.save(new Webhook(url, true, active));
+  }
+}

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListenerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListenerTest.java
@@ -1,0 +1,71 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.bbmri_eric.negotiator.info_submission.InformationSubmissionEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEvent;
+
+@ExtendWith(MockitoExtension.class)
+class WebhookEventListenerTest {
+
+  @Mock private WebhookService webhookService;
+
+  @Mock private ObjectMapper objectMapper;
+
+  @Mock private ObjectMapper eventObjectMapper;
+
+  private WebhookEventListener webhookEventListener;
+
+  @BeforeEach
+  void setUp() {
+    when(objectMapper.copy()).thenReturn(eventObjectMapper);
+    when(eventObjectMapper.addMixIn(eq(ApplicationEvent.class), any()))
+        .thenReturn(eventObjectMapper);
+    webhookEventListener = new WebhookEventListener(webhookService, objectMapper);
+  }
+
+  @Test
+  void onWebhookEvent_whenEventTypeIsNotDispatched_shouldIgnoreEvent()
+      throws JsonProcessingException {
+    ApplicationEvent unsupportedEvent = new ApplicationEvent(this) {};
+
+    webhookEventListener.onWebhookEvent(unsupportedEvent);
+
+    verify(eventObjectMapper, never()).writeValueAsString(any());
+    verify(webhookService, never()).deliverToActiveWebhooks(any(), any());
+  }
+
+  @Test
+  void onWebhookEvent_whenPayloadSerializationFails_shouldNotDeliverWebhook()
+      throws JsonProcessingException {
+    InformationSubmissionEvent event = new InformationSubmissionEvent(this, "negotiation-1");
+    when(eventObjectMapper.writeValueAsString(event))
+        .thenThrow(new JsonProcessingException("serialization failed") {});
+
+    webhookEventListener.onWebhookEvent(event);
+
+    verify(webhookService, never()).deliverToActiveWebhooks(any(), any());
+  }
+
+  @Test
+  void onWebhookEvent_whenEventIsDispatched_shouldDeliverWebhook() throws JsonProcessingException {
+    InformationSubmissionEvent event = new InformationSubmissionEvent(this, "negotiation-1");
+    when(eventObjectMapper.writeValueAsString(event)).thenReturn("{\"id\":\"negotiation-1\"}");
+
+    webhookEventListener.onWebhookEvent(event);
+
+    verify(webhookService)
+        .deliverToActiveWebhooks("{\"id\":\"negotiation-1\"}", "InformationSubmissionEvent");
+  }
+}

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListenerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListenerTest.java
@@ -1,7 +1,6 @@
 package eu.bbmri_eric.negotiator.webhook;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -9,6 +8,12 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.bbmri_eric.negotiator.info_submission.InformationSubmissionEvent;
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventEnvelope;
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventMapper;
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,26 +28,25 @@ class WebhookEventListenerTest {
 
   @Mock private ObjectMapper objectMapper;
 
-  @Mock private ObjectMapper eventObjectMapper;
+  @Mock private WebhookEventMapper webhookEventMapper;
 
   private WebhookEventListener webhookEventListener;
 
   @BeforeEach
   void setUp() {
-    when(objectMapper.copy()).thenReturn(eventObjectMapper);
-    when(eventObjectMapper.addMixIn(eq(ApplicationEvent.class), any()))
-        .thenReturn(eventObjectMapper);
-    webhookEventListener = new WebhookEventListener(webhookService, objectMapper);
+    webhookEventListener =
+        new WebhookEventListener(webhookService, objectMapper, webhookEventMapper);
   }
 
   @Test
   void onWebhookEvent_whenEventTypeIsNotDispatched_shouldIgnoreEvent()
       throws JsonProcessingException {
     ApplicationEvent unsupportedEvent = new ApplicationEvent(this) {};
+    when(webhookEventMapper.map(unsupportedEvent)).thenReturn(Optional.empty());
 
     webhookEventListener.onWebhookEvent(unsupportedEvent);
 
-    verify(eventObjectMapper, never()).writeValueAsString(any());
+    verify(objectMapper, never()).writeValueAsString(any());
     verify(webhookService, never()).deliverToActiveWebhooks(any(), any());
   }
 
@@ -50,7 +54,13 @@ class WebhookEventListenerTest {
   void onWebhookEvent_whenPayloadSerializationFails_shouldNotDeliverWebhook()
       throws JsonProcessingException {
     InformationSubmissionEvent event = new InformationSubmissionEvent(this, "negotiation-1");
-    when(eventObjectMapper.writeValueAsString(event))
+    WebhookEventEnvelope<Map<String, String>> envelope =
+        new WebhookEventEnvelope<>(
+            WebhookEventType.NEGOTIATION_INFO_UPDATED,
+            Instant.parse("2026-01-01T00:00:00Z"),
+            Map.of("negotiationId", "negotiation-1"));
+    when(webhookEventMapper.map(event)).thenReturn(Optional.of(envelope));
+    when(objectMapper.writeValueAsString(envelope))
         .thenThrow(new JsonProcessingException("serialization failed") {});
 
     webhookEventListener.onWebhookEvent(event);
@@ -61,11 +71,20 @@ class WebhookEventListenerTest {
   @Test
   void onWebhookEvent_whenEventIsDispatched_shouldDeliverWebhook() throws JsonProcessingException {
     InformationSubmissionEvent event = new InformationSubmissionEvent(this, "negotiation-1");
-    when(eventObjectMapper.writeValueAsString(event)).thenReturn("{\"id\":\"negotiation-1\"}");
+    WebhookEventEnvelope<Map<String, String>> envelope =
+        new WebhookEventEnvelope<>(
+            WebhookEventType.NEGOTIATION_INFO_UPDATED,
+            Instant.parse("2026-01-01T00:00:00Z"),
+            Map.of("negotiationId", "negotiation-1"));
+    when(webhookEventMapper.map(event)).thenReturn(Optional.of(envelope));
+    when(objectMapper.writeValueAsString(envelope))
+        .thenReturn("{\"data\":{\"negotiationId\":\"negotiation-1\"}}");
 
     webhookEventListener.onWebhookEvent(event);
 
     verify(webhookService)
-        .deliverToActiveWebhooks("{\"id\":\"negotiation-1\"}", "InformationSubmissionEvent");
+        .deliverToActiveWebhooks(
+            "{\"data\":{\"negotiationId\":\"negotiation-1\"}}",
+            WebhookEventType.NEGOTIATION_INFO_UPDATED);
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListenerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListenerTest.java
@@ -47,7 +47,7 @@ class WebhookEventListenerTest {
     webhookEventListener.onWebhookEvent(unsupportedEvent);
 
     verify(objectMapper, never()).writeValueAsString(any());
-    verify(webhookService, never()).deliverToActiveWebhooks(any(), any());
+    verify(webhookService, never()).deliverToActiveWebhooks(any(), any(), any());
   }
 
   @Test
@@ -60,12 +60,12 @@ class WebhookEventListenerTest {
             Instant.parse("2026-01-01T00:00:00Z"),
             Map.of("negotiationId", "negotiation-1"));
     when(webhookEventMapper.map(event)).thenReturn(Optional.of(envelope));
-    when(objectMapper.writeValueAsString(envelope))
+    when(objectMapper.writeValueAsString(envelope.data()))
         .thenThrow(new JsonProcessingException("serialization failed") {});
 
     webhookEventListener.onWebhookEvent(event);
 
-    verify(webhookService, never()).deliverToActiveWebhooks(any(), any());
+    verify(webhookService, never()).deliverToActiveWebhooks(any(), any(), any());
   }
 
   @Test
@@ -77,14 +77,15 @@ class WebhookEventListenerTest {
             Instant.parse("2026-01-01T00:00:00Z"),
             Map.of("negotiationId", "negotiation-1"));
     when(webhookEventMapper.map(event)).thenReturn(Optional.of(envelope));
-    when(objectMapper.writeValueAsString(envelope))
-        .thenReturn("{\"data\":{\"negotiationId\":\"negotiation-1\"}}");
+    when(objectMapper.writeValueAsString(envelope.data()))
+        .thenReturn("{\"negotiationId\":\"negotiation-1\"}");
 
     webhookEventListener.onWebhookEvent(event);
 
     verify(webhookService)
         .deliverToActiveWebhooks(
-            "{\"data\":{\"negotiationId\":\"negotiation-1\"}}",
-            WebhookEventType.NEGOTIATION_INFO_UPDATED);
+            "{\"negotiationId\":\"negotiation-1\"}",
+            WebhookEventType.NEGOTIATION_INFO_UPDATED,
+            Instant.parse("2026-01-01T00:00:00Z"));
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapperTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapperTest.java
@@ -1,0 +1,130 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.bbmri_eric.negotiator.info_submission.InformationSubmissionEvent;
+import eu.bbmri_eric.negotiator.negotiation.NewNegotiationEvent;
+import eu.bbmri_eric.negotiator.negotiation.NewResourcesAddedEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationStateChangeEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.ResourceStateChangeEvent;
+import eu.bbmri_eric.negotiator.post.NewPostEvent;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEvent;
+
+class WebhookEventMapperTest {
+
+  private WebhookEventMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new WebhookEventMapper(new ObjectMapper());
+  }
+
+  @Test
+  void map_whenEventIsUnsupported_returnsEmpty() {
+    ApplicationEvent unsupportedEvent = new ApplicationEvent(this) {};
+
+    Optional<WebhookEventEnvelope<?>> mapped = mapper.map(unsupportedEvent);
+
+    assertThat(mapped).isEmpty();
+  }
+
+  @Test
+  void map_whenInformationSubmissionEvent_returnsStableEventTypeAndData() {
+    InformationSubmissionEvent event = new InformationSubmissionEvent(this, "negotiation-1");
+
+    Optional<WebhookEventEnvelope<?>> mapped = mapper.map(event);
+
+    assertThat(mapped).isPresent();
+    assertThat(mapped.get().eventType()).isEqualTo(WebhookEventType.NEGOTIATION_INFO_UPDATED);
+    assertThat(mapped.get().occurredAt()).isNotNull();
+    assertThat(mapped.get().data())
+        .isEqualTo(new NegotiationInfoUpdatedWebhookEvent("negotiation-1"));
+  }
+
+  @Test
+  void map_whenNegotiationStateChangeEvent_returnsStableEventTypeAndData() {
+    NegotiationStateChangeEvent event =
+        new NegotiationStateChangeEvent(
+            this, "negotiation-2", NegotiationState.SUBMITTED, NegotiationEvent.SUBMIT, "post");
+
+    Optional<WebhookEventEnvelope<?>> mapped = mapper.map(event);
+
+    assertThat(mapped).isPresent();
+    assertThat(mapped.get().eventType()).isEqualTo(WebhookEventType.NEGOTIATION_STATE_UPDATED);
+    assertThat(mapped.get().occurredAt()).isNotNull();
+    assertThat(mapped.get().data())
+        .isEqualTo(
+            new NegotiationStateUpdatedWebhookEvent(
+                "negotiation-2", NegotiationState.SUBMITTED, NegotiationEvent.SUBMIT, "post"));
+  }
+
+  @Test
+  void map_whenNewNegotiationEvent_returnsStableEventTypeAndData() {
+    NewNegotiationEvent event = new NewNegotiationEvent(this, "negotiation-3");
+
+    Optional<WebhookEventEnvelope<?>> mapped = mapper.map(event);
+
+    assertThat(mapped).isPresent();
+    assertThat(mapped.get().eventType()).isEqualTo(WebhookEventType.NEGOTIATION_ADDED);
+    assertThat(mapped.get().occurredAt()).isNotNull();
+    assertThat(mapped.get().data()).isEqualTo(new NegotiationAddedWebhookEvent("negotiation-3"));
+  }
+
+  @Test
+  void map_whenNewResourcesAddedEvent_returnsStableEventTypeAndData() {
+    NewResourcesAddedEvent event = new NewResourcesAddedEvent(this, "negotiation-4");
+
+    Optional<WebhookEventEnvelope<?>> mapped = mapper.map(event);
+
+    assertThat(mapped).isPresent();
+    assertThat(mapped.get().eventType()).isEqualTo(WebhookEventType.NEGOTIATION_RESOURCE_ADDED);
+    assertThat(mapped.get().occurredAt()).isNotNull();
+    assertThat(mapped.get().data())
+        .isEqualTo(new NegotiationResourceUpdatedWebhookEvent("negotiation-4"));
+  }
+
+  @Test
+  void map_whenNewPostEvent_returnsStableEventTypeAndData() {
+    NewPostEvent event = new NewPostEvent(this, "post-1", "negotiation-5", 1000L, 2000L);
+
+    Optional<WebhookEventEnvelope<?>> mapped = mapper.map(event);
+
+    assertThat(mapped).isPresent();
+    assertThat(mapped.get().eventType()).isEqualTo(WebhookEventType.NEGOTIATION_POST_ADDED);
+    assertThat(mapped.get().occurredAt()).isNotNull();
+    assertThat(mapped.get().data())
+        .isEqualTo(new NegotiationPostAddedWebhookEvent("post-1", "negotiation-5", 1000L, 2000L));
+  }
+
+  @Test
+  void map_whenResourceStateChangeEvent_returnsStableEventTypeAndData() {
+    ResourceStateChangeEvent event =
+        new ResourceStateChangeEvent(
+            this,
+            "negotiation-5",
+            "resource-1",
+            NegotiationResourceState.SUBMITTED,
+            NegotiationResourceState.RESOURCE_AVAILABLE);
+
+    Optional<WebhookEventEnvelope<?>> mapped = mapper.map(event);
+
+    assertThat(mapped).isPresent();
+    assertThat(mapped.get().eventType())
+        .isEqualTo(WebhookEventType.NEGOTIATION_RESOURCE_STATE_UPDATED);
+    assertThat(mapped.get().occurredAt()).isNotNull();
+    assertThat(mapped.get().data())
+        .isEqualTo(
+            new NegotiationResourceStateUpdatedWebhookEvent(
+                "negotiation-5",
+                "resource-1",
+                NegotiationResourceState.SUBMITTED,
+                NegotiationResourceState.RESOURCE_AVAILABLE));
+  }
+}


### PR DESCRIPTION
### Description:

This pull request introduces a new event-driven webhook dispatch system that automatically sends JSON payloads to all active webhooks when specific domain events occur. The system ensures that each webhook receives an event-type header, and includes comprehensive integration tests to verify correct behavior.

**Webhook dispatch system:**

* Added a new `WebhookEventListener` component that listens for key domain events (such as `NegotiationStateChangeEvent`, `ResourceStateChangeEvent`, `NewPostEvent`, and `InformationSubmissionEvent`) and dispatches JSON payloads to all active webhooks with an event-type header. (`WebhookEventListener.java`)
* Introduced a new method `deliverToActiveWebhooks` in `WebhookService` and its implementation, which sends the event payload to all active webhooks, including the event type as a custom header. (`WebhookService.java`, `WebhookServiceImpl.java`) [[1]](diffhunk://#diff-cad39a2c9803f1593f123d4cc2b5828f898eee5f31a69fdb24b15c235e4a2695R52-R59) [[2]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L84-R98) [[3]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L100-R117) [[4]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L130-R149)
* Added the constant `EVENT_TYPE` header definition in a new `WebhookHeaders` class for consistent header naming. (`WebhookHeaders.java`)
* Updated `WebhookRepository` with a `findByActiveTrue()` method to efficiently fetch only active webhooks. (`WebhookRepository.java`)

**Testing and validation:**

* Added an integration test class that verifies events are dispatched only to active webhooks and include the correct event-type header for each supported event. (`WebhookEventListenerIntegrationTest.java`)## Negotiator pull request:

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
