### PR TITLE
fix: display only two letters for  in avatar

### DIFF
--- a/frontend/src/components/ProfileSettings.vue
+++ b/frontend/src/components/ProfileSettings.vue
@@ -157,8 +157,6 @@ const returnAcronymOfName = computed(() => {
   } else if (words.length > 1) {
     // Multiple words: take first letter of first and last word
     initials = words[0][0].toUpperCase() + ' ' + words[words.length - 1][0].toUpperCase()
-  } else {
-    initials = ''
   }
   return initials
 })


### PR DESCRIPTION
### Description:

- Updated the logic for displaying user initials in the profile avatar.
- Now always shows the first letter of the first and last words in the user's name (e.g., "John Doe" → "J D", "John Doe George" → "J G", "John" → "J")
- Ensures consistent and clear avatar initials for both single and multi-word names.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
