### PR TITLE
fix: initial load for options on option only access form fails

### DIFF
--- a/frontend/src/components/form-components/AccessFormSection.vue
+++ b/frontend/src/components/form-components/AccessFormSection.vue
@@ -80,7 +80,11 @@
             <span class="text-muted">Loading options...</span>
           </div>
           <div v-else>
-            <div class="form-check form-check-inline" v-for="(value, index) in negotiationValueSets[element.id]?.availableValues">
+            <div
+              class="form-check form-check-inline"
+              v-for="(value, index) in negotiationValueSets[element.id]?.availableValues"
+              :key="`${element.id}-${value}`"
+            >
               <input
                 :id="`inlineCheckbox-${element.id}-${index}`"
                 v-model="element.value"
@@ -109,7 +113,11 @@
             <span class="text-muted">Loading options...</span>
           </div>
           <div v-else>
-            <div class="form-check form-check-inline" v-for="(value, index) in negotiationValueSets[element.id]?.availableValues">
+            <div
+              class="form-check form-check-inline"
+              v-for="(value, index) in negotiationValueSets[element.id]?.availableValues"
+              :key="`${element.id}-${value}`"
+            >
               <input
                 :id="`inlineRadio-${element.id}-${index}`"
                 v-model="element.value"
@@ -207,7 +215,7 @@
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useNegotiationFormStore } from '../../store/negotiationForm'
 import { useNotificationsStore } from '../../store/notifications'
 
@@ -244,9 +252,17 @@ const props = defineProps({
 })
 
 // --- Robust value set loading pattern ---
-import { watch } from 'vue'
 const negotiationValueSets = ref({})
 const valueSetsLoading = ref(false)
+
+// Computed property to track choice element IDs for targeted watching
+const choiceElementIds = computed(() => {
+  const elements = accessFormWithPayloadSection.value?.elements || []
+  return elements
+    .filter(e => e.type === 'MULTIPLE_CHOICE' || e.type === 'SINGLE_CHOICE')
+    .map(e => e.id)
+    .join(',')
+})
 
 function loadValueSets() {
   valueSetsLoading.value = true
@@ -254,26 +270,28 @@ function loadValueSets() {
   const promises = elements
     .filter(e => e.type === 'MULTIPLE_CHOICE' || e.type === 'SINGLE_CHOICE')
     .map(e =>
-      negotiationFormStore.retrieveDynamicAccessFormsValueSetByID(e.id).then(res => {
-        negotiationValueSets.value[e.id] = res
-      })
+      negotiationFormStore.retrieveDynamicAccessFormsValueSetByID(e.id)
+        .then(res => {
+          negotiationValueSets.value[e.id] = res
+        })
+        .catch(() => {
+          // Fallback to empty values on error
+          negotiationValueSets.value[e.id] = { availableValues: [] }
+        })
     )
-  Promise.all(promises).finally(() => {
+  Promise.allSettled(promises).finally(() => {
     valueSetsLoading.value = false
   })
 }
 
 onMounted(loadValueSets)
 
-watch(
-  () => accessFormWithPayloadSection.value?.elements,
-  (newElements, oldElements) => {
-    if (newElements !== oldElements) {
-      loadValueSets()
-    }
-  },
-  { deep: true }
-)
+// Watch only the element IDs to avoid triggering on user input changes
+watch(choiceElementIds, (newIds, oldIds) => {
+  if (newIds !== oldIds) {
+    loadValueSets()
+  }
+})
 
 function handleFileUpload(event, indexOfElement) {
   if (

--- a/frontend/src/components/modals/FormSubmissionModal.vue
+++ b/frontend/src/components/modals/FormSubmissionModal.vue
@@ -115,9 +115,7 @@
                         :value="value"
                         :required="criteria.required"
                         class="form-check-input"
-                        :class="
-                          validationColorHighlight && validationColorHighlight && validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''
-                        "
+                        :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
                         type="checkbox"
                       />
                       <label class="form-check-label" for="inlineCheckbox1">{{ value }}</label>
@@ -148,9 +146,7 @@
                         :value="value"
                         :required="criteria.required"
                         class="form-check-input"
-                        :class="
-                          validationColorHighlight && validationColorHighlight && validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''
-                        "
+                        :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
                         type="radio"
                         @click="uncheckRadioButton(value, section.name, criteria.name)"
                       />

--- a/frontend/src/views/CustomizeForm.vue
+++ b/frontend/src/views/CustomizeForm.vue
@@ -226,9 +226,7 @@
                         :value="value"
                         :required="criteria.required"
                         class="form-check-input"
-                        :class="
-                          validationColorHighlight && validationColorHighlight && validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''
-                        "
+                        :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
                         type="checkbox"
                       />
                       <label class="form-check-label" for="inlineCheckbox1">{{ value }}</label>
@@ -262,9 +260,7 @@
                         :value="value"
                         :required="criteria.required"
                         class="form-check-input"
-                        :class="
-                          validationColorHighlight && validationColorHighlight && validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''
-                        "
+                        :class="validationColorHighlight.includes(criteria.name) ? 'is-invalid' : ''"
                         type="radio"
                         @click="uncheckRadioButton(value, section.name, criteria.name)"
                       />


### PR DESCRIPTION
### Description:

This PR aims to fix initial option loading for “option-only” access-form scenarios by making value-set loading more robust and preventing highlight logic from throwing when highlight arrays are not available.

Changes:

Added loading UI + a (re)load mechanism for dynamic value sets in AccessFormSection.vue.
Added guards around .includes(...) checks for validation highlight arrays in multiple components.
Updated access-form element container styling to avoid calling .includes(...) on a potentially null validationErrorHighlight.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [X] I have performed a self-review of my code
- [X] I have made my code as simple as possible
- [X] I have removed all commented code
- [X] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
