### PR TITLE
feat: webhook re-delivery

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/Delivery.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/Delivery.java
@@ -1,7 +1,10 @@
 package eu.bbmri_eric.negotiator.webhook;
 
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import java.time.LocalDateTime;
@@ -37,23 +40,30 @@ public class Delivery {
   @Column(nullable = false, updatable = false)
   private LocalDateTime at;
 
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private WebhookEventType eventType;
+
   /** Optional HTTP status code from the delivery attempt. */
   private Integer httpStatusCode;
 
   /** Optional error message if the delivery attempt failed. */
   private String errorMessage;
 
-  public Delivery(String content, Integer httpStatusCode, String errorMessage) {
+  /** Optional id of the original delivery when this record is a manual redelivery. */
+  private String redeliveryOfDeliveryId;
+
+  public Delivery(
+      String content, Integer httpStatusCode, String errorMessage, WebhookEventType eventType) {
     validateStatusAndMessage(httpStatusCode, errorMessage);
     this.content = content;
     this.httpStatusCode = httpStatusCode;
     this.errorMessage = errorMessage;
+    this.eventType = eventType;
   }
 
-  public Delivery(String content, Integer httpStatusCode) {
-    validateStatusAndMessage(httpStatusCode, null);
-    this.content = content;
-    this.httpStatusCode = httpStatusCode;
+  public Delivery(String content, Integer httpStatusCode, WebhookEventType eventType) {
+    this(content, httpStatusCode, null, eventType);
   }
 
   private static void validateStatusAndMessage(Integer httpStatusCode, String errorMessage) {
@@ -80,11 +90,13 @@ public class Delivery {
         && Objects.equals(content, delivery.content)
         && Objects.equals(at, delivery.at)
         && Objects.equals(httpStatusCode, delivery.httpStatusCode)
-        && Objects.equals(errorMessage, delivery.errorMessage);
+        && Objects.equals(errorMessage, delivery.errorMessage)
+        && Objects.equals(redeliveryOfDeliveryId, delivery.redeliveryOfDeliveryId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, webhookId, content, at, httpStatusCode, errorMessage);
+    return Objects.hash(
+        id, webhookId, content, at, httpStatusCode, errorMessage, redeliveryOfDeliveryId);
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/Delivery.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/Delivery.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.EqualsAndHashCode;
@@ -27,6 +28,7 @@ import org.hibernate.type.SqlTypes;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @EqualsAndHashCode
 @Entity
+@Table(name = "webhook_delivery")
 public class Delivery {
 
   @Id private String id;

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/Delivery.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/Delivery.java
@@ -8,8 +8,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import java.time.LocalDateTime;
-import java.util.Objects;
 import java.util.UUID;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -25,6 +25,7 @@ import org.hibernate.type.SqlTypes;
 @Getter
 @Setter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@EqualsAndHashCode
 @Entity
 public class Delivery {
 
@@ -79,24 +80,5 @@ public class Delivery {
     if (id == null || id.isEmpty()) {
       id = UUID.randomUUID().toString();
     }
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (o == null || getClass() != o.getClass()) return false;
-    Delivery delivery = (Delivery) o;
-    return Objects.equals(id, delivery.id)
-        && Objects.equals(webhookId, delivery.webhookId)
-        && Objects.equals(content, delivery.content)
-        && Objects.equals(at, delivery.at)
-        && Objects.equals(httpStatusCode, delivery.httpStatusCode)
-        && Objects.equals(errorMessage, delivery.errorMessage)
-        && Objects.equals(redeliveryOfDeliveryId, delivery.redeliveryOfDeliveryId);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        id, webhookId, content, at, httpStatusCode, errorMessage, redeliveryOfDeliveryId);
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/DeliveryDTO.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/DeliveryDTO.java
@@ -22,6 +22,17 @@ public class DeliveryDTO {
       example = "123e4567-e89b-12d3-a456-426614174000")
   private String id;
 
+  @Schema(
+      description =
+          "Identifier of original delivery when this is a redelivery, equal to delivery id if not a redelivery",
+      example = "123e4567-e89b-12d3-a456-426614174000")
+  private String rootId;
+
+  @Schema(
+      description = "Flag indicating whether this delivery is a redelivery attempt",
+      example = "false")
+  private Boolean redelivery;
+
   /** JSON content of the delivery. */
   @Schema(description = "JSON content of the delivery", example = "{\"key\":\"value\"}")
   private JsonNode content;

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/DeliveryModelMapper.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/DeliveryModelMapper.java
@@ -41,8 +41,28 @@ public class DeliveryModelMapper {
         };
     TypeMap<Delivery, DeliveryDTO> entityToDto =
         modelMapper.createTypeMap(Delivery.class, DeliveryDTO.class);
+
     entityToDto.addMappings(
-        mapper ->
-            mapper.using(stringToJsonNode).map(Delivery::getContent, DeliveryDTO::setContent));
+        mapper -> {
+          mapper.using(stringToJsonNode).map(Delivery::getContent, DeliveryDTO::setContent);
+          // Skip auto-mapping for fields handled by the PostConverter to prevent ModelMapper from
+          // incorrectly matching redeliveryOfDeliveryId (String) to redelivery (Boolean).
+          mapper.skip(DeliveryDTO::setRootId);
+          mapper.skip(DeliveryDTO::setRedelivery);
+        });
+
+    // Conditional logic for rootId and redelivery flag must use a PostConverter because
+    // ModelMapper does not support conditional property access in mapper.map() lambdas.
+    entityToDto.setPostConverter(
+        ctx -> {
+          Delivery src = ctx.getSource();
+          DeliveryDTO dest = ctx.getDestination();
+          String redeliveryId = src.getRedeliveryOfDeliveryId();
+          dest.setRootId(redeliveryId != null ? redeliveryId : src.getId());
+          dest.setRedelivery(redeliveryId != null);
+          return dest;
+        });
+
+    entityToDto.validate();
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/DeliveryRepository.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/DeliveryRepository.java
@@ -1,0 +1,10 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DeliveryRepository extends JpaRepository<Delivery, String> {
+  Optional<Delivery> findByIdAndWebhookId(String id, Long webhookId);
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -87,6 +89,18 @@ public class WebhookController {
               type = "object")
           String content) {
     DeliveryDTO dto = webhookService.deliver(content, WebhookEventType.CUSTOM, id);
+    return EntityModel.of(dto);
+  }
+
+  @Operation(
+      summary = "Manually redeliver a delivery",
+      description =
+          "Creates a new delivery attempt for an existing delivery using the same payload")
+  @PostMapping(value = "/{webhookId}/deliveries/{deliveryId}/redeliver")
+  @ResponseStatus(HttpStatus.CREATED)
+  public EntityModel<DeliveryDTO> redeliver(
+      @PathVariable Long webhookId, @PathVariable String deliveryId) {
+    DeliveryDTO dto = webhookService.redeliver(webhookId, deliveryId);
     return EntityModel.of(dto);
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookService.java
@@ -53,6 +53,15 @@ public interface WebhookService {
   DeliveryDTO deliver(String jsonPayload, WebhookEventType eventType, Long webhookId);
 
   /**
+   * Creates a manual redelivery for a previously recorded delivery.
+   *
+   * @param webhookId the owning webhook id
+   * @param deliveryId the source delivery id to redeliver
+   * @return a DTO representing the newly created delivery attempt
+   */
+  DeliveryDTO redeliver(Long webhookId, String deliveryId);
+
+  /**
    * Creates a new delivery for all active webhooks with an event type header.
    *
    * @param jsonPayload the JSON content for the delivery

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImpl.java
@@ -7,6 +7,7 @@ import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotNull;
 import java.net.SocketTimeoutException;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
 import javax.net.ssl.SSLException;
 import org.apache.commons.lang3.StringUtils;
@@ -29,16 +30,19 @@ public class WebhookServiceImpl implements WebhookService {
   private static final String SSL_VALIDATION_ERROR_MESSAGE = "SSL certificate validation failed";
 
   private final WebhookRepository webhookRepository;
+  private final DeliveryRepository deliveryRepository;
   private final ModelMapper modelMapper;
   private final RestTemplate secureRestTemplate;
   private final RestTemplate insecureRestTemplate;
 
   public WebhookServiceImpl(
       WebhookRepository webhookRepository,
+      DeliveryRepository deliveryRepository,
       ModelMapper modelMapper,
       @Qualifier("secureWebhookRestTemplate") RestTemplate secureRestTemplate,
       @Qualifier("insecureWebhookRestTemplate") RestTemplate insecureRestTemplate) {
     this.webhookRepository = webhookRepository;
+    this.deliveryRepository = deliveryRepository;
     this.modelMapper = modelMapper;
     this.secureRestTemplate = secureRestTemplate;
     this.insecureRestTemplate = insecureRestTemplate;
@@ -95,7 +99,37 @@ public class WebhookServiceImpl implements WebhookService {
     Webhook webhook = getWebhook(webhookId);
     RestTemplate restTemplate =
         webhook.isSslVerification() ? secureRestTemplate : insecureRestTemplate;
-    return deliverWebhook(jsonPayload, restTemplate, webhook, eventType, Instant.now());
+    return deliverWebhook(jsonPayload, restTemplate, webhook, eventType, Instant.now(), null);
+  }
+
+  @Override
+  @Transactional
+  public DeliveryDTO redeliver(Long webhookId, String deliveryId) {
+    Webhook webhook = getWebhook(webhookId);
+    Delivery sourceDelivery =
+        deliveryRepository
+            .findByIdAndWebhookId(deliveryId, webhookId)
+            .orElseThrow(() -> new EntityNotFoundException(deliveryId));
+
+    RestTemplate restTemplate =
+        webhook.isSslVerification() ? secureRestTemplate : insecureRestTemplate;
+
+    Instant timestamp = Instant.from(sourceDelivery.getAt().atZone(ZoneId.systemDefault()));
+
+    // If this is a redelivery of a redelivery, we want to keep the original delivery id as
+    // reference
+    String rootDeliveryId =
+        sourceDelivery.getRedeliveryOfDeliveryId() == null
+            ? deliveryId
+            : sourceDelivery.getRedeliveryOfDeliveryId();
+
+    return deliverWebhook(
+        sourceDelivery.getContent(),
+        restTemplate,
+        webhook,
+        sourceDelivery.getEventType(),
+        timestamp,
+        rootDeliveryId);
   }
 
   @Override
@@ -109,7 +143,7 @@ public class WebhookServiceImpl implements WebhookService {
     for (Webhook webhook : webhooks) {
       RestTemplate restTemplate =
           webhook.isSslVerification() ? secureRestTemplate : insecureRestTemplate;
-      deliverWebhook(jsonPayload, restTemplate, webhook, eventType, occurredAt);
+      deliverWebhook(jsonPayload, restTemplate, webhook, eventType, occurredAt, null);
     }
   }
 
@@ -130,32 +164,36 @@ public class WebhookServiceImpl implements WebhookService {
       RestTemplate restTemplate,
       Webhook webhook,
       WebhookEventType eventType,
-      Instant occurredAt) {
+      Instant occurredAt,
+      String redeliveryOfDeliveryId) {
     Delivery delivery;
     try {
       HttpEntity<String> request = buildHttpEntity(jsonPayload, eventType, occurredAt);
       int statusCode = postWebhook(restTemplate, webhook, request);
-      delivery = new Delivery(jsonPayload, statusCode);
+      delivery = new Delivery(jsonPayload, statusCode, eventType);
     } catch (HttpClientErrorException | HttpServerErrorException ex) {
-      delivery = new Delivery(jsonPayload, ex.getStatusCode().value(), parseErrorMessage(ex));
+      delivery =
+          new Delivery(jsonPayload, ex.getStatusCode().value(), parseErrorMessage(ex), eventType);
     } catch (ResourceAccessException ex) {
-      delivery = mapTransportException(jsonPayload, ex);
+      delivery = mapTransportException(jsonPayload, ex, eventType);
     } catch (Exception ex) {
-      delivery = new Delivery(jsonPayload, null, parseErrorMessage(ex));
+      delivery = new Delivery(jsonPayload, null, parseErrorMessage(ex), eventType);
     }
+    delivery.setRedeliveryOfDeliveryId(redeliveryOfDeliveryId);
     return persistDelivery(webhook, delivery);
   }
 
-  private Delivery mapTransportException(String jsonPayload, ResourceAccessException ex) {
+  private Delivery mapTransportException(
+      String jsonPayload, ResourceAccessException ex, WebhookEventType eventType) {
     if (containsCause(ex, ConnectTimeoutException.class)
         || containsCause(ex, SocketTimeoutException.class)) {
-      return new Delivery(jsonPayload, null, REQUEST_TIMEOUT_ERROR_MESSAGE);
+      return new Delivery(jsonPayload, null, REQUEST_TIMEOUT_ERROR_MESSAGE, eventType);
     }
 
     if (containsCause(ex, SSLException.class)) {
-      return new Delivery(jsonPayload, null, SSL_VALIDATION_ERROR_MESSAGE);
+      return new Delivery(jsonPayload, null, SSL_VALIDATION_ERROR_MESSAGE, eventType);
     }
-    return new Delivery(jsonPayload, null, parseErrorMessage(ex));
+    return new Delivery(jsonPayload, null, parseErrorMessage(ex), eventType);
   }
 
   private DeliveryDTO persistDelivery(Webhook webhook, Delivery delivery) {

--- a/backend/src/main/resources/db/migration/V32.1__add_redelivery_reference_to_delivery.sql
+++ b/backend/src/main/resources/db/migration/V32.1__add_redelivery_reference_to_delivery.sql
@@ -1,11 +1,5 @@
 ALTER TABLE delivery
-ADD COLUMN redelivery_of_delivery_id VARCHAR(36);
+ADD COLUMN IF NOT EXISTS redelivery_of_delivery_id VARCHAR(36);
 
-ALTER TABLE delivery
-ADD CONSTRAINT fk_delivery_redelivery_of
-FOREIGN KEY (redelivery_of_delivery_id)
-REFERENCES delivery (id)
-ON DELETE SET NULL;
-
-CREATE INDEX idx_delivery_redelivery_of
+CREATE INDEX IF NOT EXISTS idx_delivery_redelivery_of
 ON delivery (redelivery_of_delivery_id);

--- a/backend/src/main/resources/db/migration/V32.1__add_redelivery_reference_to_delivery.sql
+++ b/backend/src/main/resources/db/migration/V32.1__add_redelivery_reference_to_delivery.sql
@@ -1,0 +1,11 @@
+ALTER TABLE delivery
+ADD COLUMN redelivery_of_delivery_id VARCHAR(36);
+
+ALTER TABLE delivery
+ADD CONSTRAINT fk_delivery_redelivery_of
+FOREIGN KEY (redelivery_of_delivery_id)
+REFERENCES delivery (id)
+ON DELETE SET NULL;
+
+CREATE INDEX idx_delivery_redelivery_of
+ON delivery (redelivery_of_delivery_id);

--- a/backend/src/main/resources/db/migration/V32.2__add_event_type_to_delivery.sql
+++ b/backend/src/main/resources/db/migration/V32.2__add_event_type_to_delivery.sql
@@ -1,0 +1,9 @@
+ALTER TABLE delivery
+ADD COLUMN event_type VARCHAR(64);
+
+UPDATE delivery
+SET event_type = 'CUSTOM'
+WHERE event_type IS NULL;
+
+ALTER TABLE delivery
+ALTER COLUMN event_type SET NOT NULL;

--- a/backend/src/main/resources/db/migration/V32.3__rename_delivery_to_webhook_delivery.sql
+++ b/backend/src/main/resources/db/migration/V32.3__rename_delivery_to_webhook_delivery.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS delivery
+RENAME TO webhook_delivery;

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/WebhookControllerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/WebhookControllerTest.java
@@ -10,6 +10,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -32,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -295,6 +297,188 @@ public class WebhookControllerTest {
 
     // Verify that the stub endpoint received a POST request with the expected JSON payload.
     verify(
+        postRequestedFor(urlEqualTo("/test-endpoint"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(equalToJson(payload)));
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void redeliver_validDelivery_returnsCreatedAndLinksToOriginal(WireMockRuntimeInfo wmRuntimeInfo)
+      throws Exception {
+    String url = wmRuntimeInfo.getHttpBaseUrl() + "/test-endpoint";
+    Webhook webhook = webhookRepository.save(new Webhook(url, true, true));
+    stubFor(
+        post(urlEqualTo("/test-endpoint"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                    .withBody("{\"status\":\"received\"}")));
+
+    String payload = "{\"data\":\"redelivery\"}";
+
+    MvcResult firstDeliveryResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post(
+                        String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String sourceDeliveryId =
+        objectMapper
+            .readTree(firstDeliveryResult.getResponse().getContentAsString())
+            .get("id")
+            .asText();
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post(
+                    String.format(
+                        "/v3/webhooks/%d/deliveries/%s/redeliver",
+                        webhook.getId(), sourceDeliveryId))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id", not(sourceDeliveryId)))
+        .andExpect(jsonPath("$.rootId", is(sourceDeliveryId)))
+        .andExpect(jsonPath("$.redelivery", is(true)))
+        .andExpect(jsonPath("$.httpStatusCode", is(200)))
+        .andExpect(jsonPath("$.errorMessage").doesNotExist());
+
+    verify(
+        2,
+        postRequestedFor(urlEqualTo("/test-endpoint"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(equalToJson(payload)));
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void redeliver_unknownDelivery_returns4xx(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    String url = wmRuntimeInfo.getHttpBaseUrl() + "/test-endpoint";
+    Webhook webhook = webhookRepository.save(new Webhook(url, true, true));
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post(
+                    String.format(
+                        "/v3/webhooks/%d/deliveries/%s/redeliver",
+                        webhook.getId(), "unknown-delivery"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().is4xxClientError());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void redeliver_inactiveWebhook_returnsBadRequest(WireMockRuntimeInfo wmRuntimeInfo)
+      throws Exception {
+    String url = wmRuntimeInfo.getHttpBaseUrl() + "/test-endpoint";
+    Webhook webhook = webhookRepository.save(new Webhook(url, true, true));
+    stubFor(
+        post(urlEqualTo("/test-endpoint")).willReturn(aResponse().withStatus(200).withBody("OK")));
+
+    String payload = "{\"data\":\"redelivery\"}";
+    MvcResult firstDeliveryResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post(
+                        String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload))
+            .andExpect(status().isOk())
+            .andReturn();
+    String sourceDeliveryId =
+        objectMapper
+            .readTree(firstDeliveryResult.getResponse().getContentAsString())
+            .get("id")
+            .asText();
+
+    webhook.setActive(false);
+    webhookRepository.save(webhook);
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post(
+                    String.format(
+                        "/v3/webhooks/%d/deliveries/%s/redeliver",
+                        webhook.getId(), sourceDeliveryId))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(
+            jsonPath(
+                "$.detail", containsString("Webhook is not active, therefore cannot deliver")));
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void redeliver_redeliveryOfRedelivery_preservesOriginalRootId(WireMockRuntimeInfo wmRuntimeInfo)
+      throws Exception {
+    String url = wmRuntimeInfo.getHttpBaseUrl() + "/test-endpoint";
+    Webhook webhook = webhookRepository.save(new Webhook(url, true, true));
+    stubFor(
+        post(urlEqualTo("/test-endpoint"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                    .withBody("{\"status\":\"received\"}")));
+
+    String payload = "{\"data\":\"redelivery\"}";
+
+    MvcResult sourceDeliveryResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post(
+                        String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String sourceDeliveryId =
+        objectMapper
+            .readTree(sourceDeliveryResult.getResponse().getContentAsString())
+            .get("id")
+            .asText();
+
+    MvcResult firstRedeliveryResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post(
+                        String.format(
+                            "/v3/webhooks/%d/deliveries/%s/redeliver",
+                            webhook.getId(), sourceDeliveryId))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.rootId", is(sourceDeliveryId)))
+            .andExpect(jsonPath("$.redelivery", is(true)))
+            .andReturn();
+
+    String firstRedeliveryId =
+        objectMapper
+            .readTree(firstRedeliveryResult.getResponse().getContentAsString())
+            .get("id")
+            .asText();
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post(
+                    String.format(
+                        "/v3/webhooks/%d/deliveries/%s/redeliver",
+                        webhook.getId(), firstRedeliveryId))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id", not(firstRedeliveryId)))
+        .andExpect(jsonPath("$.rootId", is(sourceDeliveryId)))
+        .andExpect(jsonPath("$.redelivery", is(true)))
+        .andExpect(jsonPath("$.httpStatusCode", is(200)))
+        .andExpect(jsonPath("$.errorMessage").doesNotExist());
+
+    verify(
+        3,
         postRequestedFor(urlEqualTo("/test-endpoint"))
             .withHeader("Content-Type", equalTo("application/json"))
             .withRequestBody(equalToJson(payload)));

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookDeliveryTransportFaultIntegrationTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookDeliveryTransportFaultIntegrationTest.java
@@ -83,9 +83,10 @@ class WebhookDeliveryTransportFaultIntegrationTest {
 
   @Test
   void deliver_withUnexpectedRuntimeException_setsNullStatusAndErrorMessage() {
-    // Simulate an unexpected runtime exception by providing an invalid URL that causes the HTTP
-    // client to throw an exception
-    Webhook webhook = webhookRepository.save(new Webhook("", true, true));
+    // Simulate an unexpected internal runtime exception (not a transport failure).
+    // RestTemplate will fail URI template expansion with IllegalArgumentException.
+    Webhook webhook =
+        webhookRepository.save(new Webhook("http://localhost/{missingVar}", true, true));
 
     String payload = "{\"data\":\"runtime\"}";
 

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookRedeliveryIntegrationTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookRedeliveryIntegrationTest.java
@@ -1,0 +1,77 @@
+package eu.bbmri_eric.negotiator.integration.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import eu.bbmri_eric.negotiator.util.IntegrationTest;
+import eu.bbmri_eric.negotiator.webhook.DeliveryDTO;
+import eu.bbmri_eric.negotiator.webhook.Webhook;
+import eu.bbmri_eric.negotiator.webhook.WebhookRepository;
+import eu.bbmri_eric.negotiator.webhook.WebhookService;
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+@IntegrationTest
+@WireMockTest
+public class WebhookRedeliveryIntegrationTest {
+
+  @Autowired private WebhookRepository webhookRepository;
+
+  @Autowired private WebhookService webhookService;
+
+  @BeforeEach
+  void setUp() {
+    webhookRepository.deleteAll();
+  }
+
+  @Test
+  void redeliver_redeliveryOfRedelivery_preservesOriginalRootId(WireMockRuntimeInfo wmInfo) {
+    String url = wmInfo.getHttpBaseUrl() + "/redeliver-endpoint";
+    Webhook webhook = webhookRepository.save(new Webhook(url, true, true));
+
+    stubFor(
+        post(urlEqualTo("/redeliver-endpoint"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                    .withBody("{\"status\":\"received\"}")));
+
+    String payload = "{\"data\":\"redelivery\"}";
+
+    DeliveryDTO firstDelivery =
+        webhookService.deliver(payload, WebhookEventType.CUSTOM, webhook.getId());
+    DeliveryDTO redelivery = webhookService.redeliver(webhook.getId(), firstDelivery.getId());
+    DeliveryDTO secondRedelivery = webhookService.redeliver(webhook.getId(), redelivery.getId());
+
+    assertEquals(200, redelivery.getHttpStatusCode());
+    assertEquals(firstDelivery.getId(), redelivery.getRootId());
+    assertTrue(redelivery.getRedelivery());
+    assertNull(redelivery.getErrorMessage());
+
+    assertEquals(200, secondRedelivery.getHttpStatusCode());
+    assertEquals(firstDelivery.getId(), secondRedelivery.getRootId());
+    assertTrue(secondRedelivery.getRedelivery());
+    assertNull(secondRedelivery.getErrorMessage());
+
+    verify(
+        3,
+        postRequestedFor(urlEqualTo("/redeliver-endpoint"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(equalToJson(payload)));
+  }
+}

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/unit/model/WebhookEntityTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/unit/model/WebhookEntityTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import eu.bbmri_eric.negotiator.webhook.Delivery;
 import eu.bbmri_eric.negotiator.webhook.Webhook;
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +24,8 @@ public class WebhookEntityTest {
 
   @Test
   void testAddSingleDeliveryWith200() {
-    Delivery delivery = new Delivery("{\"message\":\"Test delivery 1\"}", 200);
+    Delivery delivery =
+        new Delivery("{\"message\":\"Test delivery 1\"}", 200, WebhookEventType.CUSTOM);
     webhook.addDelivery(delivery);
     assertEquals(1, webhook.getDeliveries().size());
     assertEquals(webhook.getId(), delivery.getWebhookId());
@@ -33,7 +35,8 @@ public class WebhookEntityTest {
   @Test
   void testAddMultipleDeliveriesWithinLimit() {
     for (int i = 1; i <= 5; i++) {
-      Delivery delivery = new Delivery("{\"message\":\"Delivery " + i + "\"}", 200);
+      Delivery delivery =
+          new Delivery("{\"message\":\"Delivery " + i + "\"}", 200, WebhookEventType.CUSTOM);
       webhook.addDelivery(delivery);
     }
     assertEquals(5, webhook.getDeliveries().size());
@@ -47,7 +50,8 @@ public class WebhookEntityTest {
   @Test
   void testAddMoreThan100Deliveries() {
     for (int i = 1; i <= 105; i++) {
-      Delivery delivery = new Delivery("{\"message\":\"Delivery " + i + "\"}", 200);
+      Delivery delivery =
+          new Delivery("{\"message\":\"Delivery " + i + "\"}", 200, WebhookEventType.CUSTOM);
       webhook.addDelivery(delivery);
     }
     assertEquals(100, webhook.getDeliveries().size());
@@ -60,13 +64,15 @@ public class WebhookEntityTest {
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new Delivery("{\"message\":\"Error delivery\"}", 500));
+            () -> new Delivery("{\"message\":\"Error delivery\"}", 500, WebhookEventType.CUSTOM));
     assertEquals("Non-200 HTTP status code requires an error message.", exception.getMessage());
   }
 
   @Test
   void testAddDeliveryNon200WithErrorMessage() {
-    Delivery delivery = new Delivery("{\"message\":\"Error delivery\"}", 500, "Server error");
+    Delivery delivery =
+        new Delivery(
+            "{\"message\":\"Error delivery\"}", 500, "Server error", WebhookEventType.CUSTOM);
     webhook.addDelivery(delivery);
     assertEquals(1, webhook.getDeliveries().size());
     assertEquals("Server error", delivery.getErrorMessage());
@@ -75,11 +81,11 @@ public class WebhookEntityTest {
 
   @Test
   void testDeliveriesOrderedByAtDescending() {
-    Delivery d1 = new Delivery("{\"message\":\"Oldest\"}", 200);
+    Delivery d1 = new Delivery("{\"message\":\"Oldest\"}", 200, WebhookEventType.CUSTOM);
     d1.setAt(LocalDateTime.now().minusMinutes(10));
-    Delivery d2 = new Delivery("{\"message\":\"Middle\"}", 200);
+    Delivery d2 = new Delivery("{\"message\":\"Middle\"}", 200, WebhookEventType.CUSTOM);
     d2.setAt(LocalDateTime.now().minusMinutes(5));
-    Delivery d3 = new Delivery("{\"message\":\"Newest\"}", 200);
+    Delivery d3 = new Delivery("{\"message\":\"Newest\"}", 200, WebhookEventType.CUSTOM);
     d3.setAt(LocalDateTime.now());
     webhook.addDelivery(d1);
     webhook.addDelivery(d2);

--- a/frontend/src/components/DeliveryHistory.vue
+++ b/frontend/src/components/DeliveryHistory.vue
@@ -17,6 +17,13 @@
             {{ expandedPayloads[delivery.id] ? 'Hide' : 'Show' }} Payload
           </button>
 
+          <button
+            class="btn btn-sm btn-outline-secondary ms-1"
+            @click="$emit('redeliver', delivery.id)"
+          >
+            Redeliver
+          </button>
+
           <div v-if="expandedPayloads[delivery.id]" class="mt-2">
             <pre class="p-2 bg-light rounded"><code>{{ formatJson(delivery.content) }}</code></pre>
           </div>
@@ -48,11 +55,17 @@
 import { ref } from 'vue'
 
 defineProps({
+  webhookId: {
+    type: String,
+    required: true,
+  },
   deliveries: {
     type: Array,
     required: true,
   },
 })
+
+defineEmits(['redeliver'])
 
 const expandedPayloads = ref({})
 

--- a/frontend/src/components/DeliveryHistory.vue
+++ b/frontend/src/components/DeliveryHistory.vue
@@ -55,10 +55,6 @@
 import { ref } from 'vue'
 
 defineProps({
-  webhookId: {
-    type: String,
-    required: true,
-  },
   deliveries: {
     type: Array,
     required: true,

--- a/frontend/src/components/WebhookCard.vue
+++ b/frontend/src/components/WebhookCard.vue
@@ -5,14 +5,6 @@
         <i :class="getStatusIcon(webhook)" class="me-3"></i>
         <div>
           <h5 class="card-title mb-0">{{ webhook.url }}</h5>
-          <small class="text-muted">
-            <span v-if="webhook.testInProgress">
-              <i class="bi bi-arrow-repeat spin"></i> Testing...
-            </span>
-            <span v-else>
-              {{ getLastDeliveryStatus(webhook) }}
-            </span>
-          </small>
         </div>
       </div>
       <div>
@@ -41,6 +33,9 @@ defineProps({
 })
 
 const getStatusIcon = (webhook) => {
+  if (webhook.testInProgress) {
+    return 'bi bi-arrow-repeat spin'
+  }
   if (!webhook.active) {
     return 'bi bi-dash-circle text-secondary'
   }
@@ -51,14 +46,6 @@ const getStatusIcon = (webhook) => {
       : 'bi bi-exclamation-triangle text-danger'
   }
   return 'bi bi-question-circle text-secondary'
-}
-
-const getLastDeliveryStatus = (webhook) => {
-  if (webhook.deliveries && webhook.deliveries.length > 0) {
-    const latest = webhook.deliveries[0]
-    return latest.httpStatusCode === 200 ? '200 OK' : `${latest.httpStatusCode} Error`
-  }
-  return 'No deliveries'
 }
 </script>
 

--- a/frontend/src/components/modals/WebhookModal.vue
+++ b/frontend/src/components/modals/WebhookModal.vue
@@ -62,7 +62,10 @@
                 role="tabpanel"
                 aria-labelledby="deliveries-tab"
               >
-                <DeliveryHistory :deliveries="webhook.deliveries" />
+                <DeliveryHistory
+                  :deliveries="webhook.deliveries"
+                  @redeliver="$emit('redeliver', { webhookId: webhook.id, deliveryId: $event })"
+                />
               </div>
             </div>
           </div>
@@ -98,7 +101,7 @@ const props = defineProps({
   id: { type: String, default: 'editWebhookModal' },
   fade: { type: Boolean, default: true },
 })
-const emit = defineEmits(['update', 'create'])
+const emit = defineEmits(['update', 'create', 'redeliver'])
 
 // Initialize a reactive form object using the webhook prop.
 const form = reactive({

--- a/frontend/src/store/admin.js
+++ b/frontend/src/store/admin.js
@@ -99,7 +99,7 @@ export const useAdminStore = defineStore('admin', () => {
         notifications.setNotification('Webhook deleted successfully')
       })
       .catch((error) => {
-        notifications.setNotification('Error deleting webhook', 'error')
+        notifications.setNotification('Error deleting webhook', 'danger')
         throw error
       })
   }
@@ -117,7 +117,7 @@ export const useAdminStore = defineStore('admin', () => {
         return response.data
       })
       .catch((error) => {
-        notifications.setNotification('Failed to send test delivery', 'error')
+        notifications.setNotification('Failed to send test delivery', 'danger')
         throw error
       })
   }
@@ -143,7 +143,7 @@ export const useAdminStore = defineStore('admin', () => {
         return response.data
       })
       .catch((error) => {
-        notifications.setNotification('Failed to redeliver webhook delivery', 'error')
+        notifications.setNotification('Failed to redeliver webhook delivery', 'danger')
         throw error
       })
   }
@@ -237,7 +237,7 @@ export const useAdminStore = defineStore('admin', () => {
         return response.data
       })
       .catch(() => {
-        notifications.setNotification('Error updating resource', 'error')
+        notifications.setNotification('Error updating resource', 'danger')
         throw new Error('Failed to update resource')
       })
   }
@@ -283,7 +283,7 @@ export const useAdminStore = defineStore('admin', () => {
         return response.data
       })
       .catch(() => {
-        notifications.setNotification('Error updating organization', 'error')
+        notifications.setNotification('Error updating organization', 'danger')
         throw new Error('Failed to update organization')
       })
   }
@@ -302,7 +302,7 @@ export const useAdminStore = defineStore('admin', () => {
         return response.data._embedded?.organizations?.[0] || response.data
       })
       .catch((error) => {
-        notifications.setNotification('Error creating organization', 'error')
+        notifications.setNotification('Error creating organization', 'danger')
         throw error
       })
   }

--- a/frontend/src/store/admin.js
+++ b/frontend/src/store/admin.js
@@ -130,6 +130,24 @@ export const useAdminStore = defineStore('admin', () => {
       .then((response) => response.data)
   }
 
+  function redeliverWebhookDelivery(webhookId, deliveryId) {
+    return axios
+      .post(
+        `${apiPaths.BASE_API_PATH}/webhooks/${webhookId}/deliveries/${deliveryId}/redeliver`,
+        null,
+        {
+          headers: getBearerHeaders(),
+        },
+      )
+      .then((response) => {
+        return response.data
+      })
+      .catch((error) => {
+        notifications.setNotification('Failed to redeliver webhook delivery', 'error')
+        throw error
+      })
+  }
+
   function retrieveUsers(page = 0, size = 10, filtersSortData) {
     // add filtersSortData in case they are valued
     const params = Object.fromEntries(
@@ -300,6 +318,7 @@ export const useAdminStore = defineStore('admin', () => {
     deleteWebhook,
     testWebhook,
     getWebhook,
+    redeliverWebhookDelivery,
     retrieveUsers,
     retrieveResources,
     retrieveResourcesPaginated,

--- a/frontend/src/views/AdminSettingsPage.vue
+++ b/frontend/src/views/AdminSettingsPage.vue
@@ -154,7 +154,7 @@ const confirmDeleteWebhook = async () => {
     notifications.setNotification('Webhook deleted successfully')
   } catch (error) {
     console.error('Error deleting webhook:', error)
-    notifications.setNotification('Error deleting webhook', 'error')
+    notifications.setNotification('Error deleting webhook', 'danger')
   } finally {
     isLoading.value = false
     webhookToDelete.value = null
@@ -198,7 +198,7 @@ const handleWebhookRedelivery = async ({ webhookId, deliveryId }) => {
     notifications.setNotification('Webhook redelivery completed', 'success')
   } catch (error) {
     console.error('Error redelivering webhook delivery:', error)
-    notifications.setNotification('Webhook redelivery failed', 'error')
+    notifications.setNotification('Webhook redelivery failed', 'danger')
   } finally {
     isLoading.value = false
   }

--- a/frontend/src/views/AdminSettingsPage.vue
+++ b/frontend/src/views/AdminSettingsPage.vue
@@ -32,6 +32,7 @@
       :webhook="selectedWebhook"
       @update="handleWebhookUpdate"
       @create="handleNewWebhook"
+      @redeliver="handleWebhookRedelivery"
     />
     <confirmation-modal
       id="delete-webhookmodal"
@@ -189,6 +190,20 @@ const handleNewWebhook = async (updatedConfig) => {
   }
 }
 
+const handleWebhookRedelivery = async ({ webhookId, deliveryId }) => {
+  try {
+    isLoading.value = true
+    await adminStore.redeliverWebhookDelivery(webhookId, deliveryId)
+    selectedWebhook.value = await updateWebhookInList(webhookId)
+    notifications.setNotification('Webhook redelivery completed', 'success')
+  } catch (error) {
+    console.error('Error redelivering webhook delivery:', error)
+    notifications.setNotification('Webhook redelivery failed', 'error')
+  } finally {
+    isLoading.value = false
+  }
+}
+
 const testWebhook = async (webhook) => {
   const index = webhooks.value.findIndex((w) => w.id === webhook.id)
   if (index === -1) return
@@ -208,6 +223,17 @@ const testWebhook = async (webhook) => {
       testInProgress: false,
     }
   }
+}
+
+const updateWebhookInList = async (webhookId) => {
+  const updatedWebhook = await adminStore.getWebhook(webhookId)
+
+  const index = webhooks.value.findIndex((w) => w.id === webhookId)
+  if (index !== -1) {
+    webhooks.value[index] = updatedWebhook
+  }
+
+  return updatedWebhook
 }
 
 const viewEmailDetails = (email) => {


### PR DESCRIPTION
### Description:

This pull request introduces support for manual redelivery of webhook deliveries, allowing users to trigger a new delivery attempt for a previous delivery and track the relationship between deliveries and their redeliveries. The changes include updates to the data model, service and controller layers, data transfer objects, and integration tests to support and verify this new feature.

**Manual Redelivery Feature:**

* Added a new API endpoint to allow manual redelivery of a specific delivery, creating a new delivery attempt with a reference to the original delivery. (`WebhookController.java`, `WebhookService.java`, `WebhookServiceImpl.java`) [[1]](diffhunk://#diff-6eb083ddecbd06e98d39c78a8065de18f15a297a71cefbb83c9d42b530ae9c2cR94-R105) [[2]](diffhunk://#diff-cad39a2c9803f1593f123d4cc2b5828f898eee5f31a69fdb24b15c235e4a2695R55-R63) [[3]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L98-R130)
* Updated the `Delivery` entity to include an optional reference (`redeliveryOfDeliveryId`) to the original delivery when a redelivery is made, and added the corresponding database migration. (`Delivery.java`, `V30.2__add_redelivery_reference_to_delivery.sql`) [[1]](diffhunk://#diff-b7f9afc39b1db9d997375ada703990440549826a3f0e0a7f0aa34519eb8ac51aR44-R67) [[2]](diffhunk://#diff-babe0078a72a4ac48ea0af6693d8a0c34823e31ce1e3b2d0a53b64ab453a0cf7R1-R11)
* Modified the `DeliveryDTO` to expose information about redeliveries, including the root delivery id and a boolean flag indicating if the delivery is a redelivery. (`DeliveryDTO.java`, `DeliveryModelMapper.java`) [[1]](diffhunk://#diff-8ff1f220688a1babf854ebf53bd9ca7a89b58103a6685faa52399723bb8dac9dR25-R35) [[2]](diffhunk://#diff-9fd709ad13b647d4e8a4f8ca822b7484e0cff9752dd864ca575f6416fe87c479L44-R53)
* Implemented repository support for looking up deliveries by both id and webhook id. (`DeliveryRepository.java`)

**Testing and Validation:**

* Added integration and service tests to verify correct behavior of the redelivery feature, including successful redelivery, error handling for unknown deliveries, and inactive webhooks. (`WebhookControllerTest.java`, `WebhookDeliverySslIntegrationTest.java`) [[1]](diffhunk://#diff-b824380a7847cf37787b2b6b5736be9188f5182ec9d5f64b08bbc18ed4856b70R304-R412) [[2]](diffhunk://#diff-97da6f2a050131536fca5992d0d1f9eb186c12fc26424643d48bfdfc5beddd71R159-R187)
### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
