### PR TITLE
fix: privacy policy links migration and defaults

### DIFF
--- a/backend/src/main/resources/db/migration/V33.0__fix_privacy_and_access_policy_defaults.sql
+++ b/backend/src/main/resources/db/migration/V33.0__fix_privacy_and_access_policy_defaults.sql
@@ -1,0 +1,27 @@
+-- Correct default URL for footerPrivacyPolicyLink
+-- The default was set to the BBMRI-ERIC access policy PDF, which we want to be empty
+-- Only update if the value has not been customised (i.e. still matches the original default).
+UPDATE ui_parameter
+SET value = ''
+WHERE category = 'footer'
+  AND name = 'footerPrivacyPolicyLink'
+  AND value = 'https://www.bbmri-eric.eu/wp-content/uploads/AoM_10_8_Access-Policy_FINAL_EU.pdf';
+
+-- Set navbarPrivacyPolicyLink (ID 71) to the current value of footerPrivacyPolicyLink
+-- This respects any customisation: if footerPrivacyPolicyLink was the default (now ''),
+-- navbar gets ''; if it was changed to a custom URL, navbar inherits that value
+UPDATE ui_parameter
+SET value = (
+    SELECT value
+    FROM ui_parameter
+    WHERE category = 'footer'
+      AND name = 'footerPrivacyPolicyLink'
+)
+WHERE category = 'navbar'
+  AND name = 'navbarPrivacyPolicyLink';
+
+-- navbarAccessPolicyLink should always be empty — no default URL should be set
+UPDATE ui_parameter
+SET value = ''
+WHERE category = 'navbar'
+  AND name = 'navbarAccessPolicyLink';

--- a/frontend/src/components/FooterComp.vue
+++ b/frontend/src/components/FooterComp.vue
@@ -115,19 +115,13 @@
             {{ uiConfiguration?.footerNewsletterText }}
           </button>
         </div>
-        <div v-if="uiConfiguration?.isFooterPrivacyPolicyVisible" class="ms-md-2 ms-5 mt-2">
+        <div v-if="showPrivacyPolicyLink" class="ms-md-2 ms-5 mt-2">
           <a
             class="me-5 link"
             :style="{ color: uiConfiguration?.footerTextColor }"
-            :href="
-              uiConfiguration?.footerPrivacyPolicyLink ||
-              uiConfigurationNavbar?.navbarPrivacyPolicyLink
-            "
+            :href="privacyPolicyLink"
           >
-            {{
-              uiConfiguration?.footerPrivacyPolicyText ||
-              uiConfigurationNavbar?.navbarPrivacyPolicyText
-            }}
+            {{ privacyPolicyText }}
           </a>
         </div>
       </div>
@@ -231,6 +225,28 @@ const returnWorkProgrammeSrc = computed(() => {
     return workProgrammeLogo
   }
   return uiConfiguration.value?.footerWorkProgrammeImageUrl
+})
+
+const privacyPolicyLink = computed(() => {
+  return (
+    uiConfiguration.value?.footerPrivacyPolicyLink ||
+    uiConfigurationNavbar.value?.navbarPrivacyPolicyLink
+  )
+})
+
+const privacyPolicyText = computed(() => {
+  return (
+    uiConfiguration.value?.footerPrivacyPolicyText ||
+    uiConfigurationNavbar.value?.navbarPrivacyPolicyText
+  )
+})
+
+const showPrivacyPolicyLink = computed(() => {
+  return Boolean(
+    uiConfiguration.value?.isFooterPrivacyPolicyVisible &&
+    privacyPolicyLink.value &&
+    privacyPolicyText.value,
+  )
 })
 </script>
 

--- a/frontend/src/components/ProfileSettings.vue
+++ b/frontend/src/components/ProfileSettings.vue
@@ -78,39 +78,27 @@
           Admin UI Configuration
         </router-link>
       </li>
-      <li>
+      <li v-if="showLegalLinksSection">
         <hr class="dropdown-divider" />
       </li>
-      <li
-        v-if="
-          (uiConfiguration?.navbarPrivacyPolicyText && uiConfiguration?.navbarPrivacyPolicyLink) ||
-          (uiConfigurationFooter?.footerPrivacyPolicyText &&
-            uiConfigurationFooter?.footerPrivacyPolicyLink)
-        "
-      >
+      <li v-if="showPrivacyPolicyLink">
         <a
-          :href="
-            uiConfiguration?.navbarPrivacyPolicyLink ||
-            uiConfigurationFooter?.footerPrivacyPolicyLink
-          "
+          :href="privacyPolicyLink"
           class="dropdown-item"
           :style="{ color: uiConfiguration?.navbarTextColor }"
         >
           <i class="bi bi-shield-lock" />
-          {{
-            uiConfiguration?.navbarPrivacyPolicyText ||
-            uiConfigurationFooter?.footerPrivacyPolicyText
-          }}
+          {{ privacyPolicyText }}
         </a>
       </li>
-      <li v-if="uiConfiguration?.navbarAccessPolicyText && uiConfiguration?.navbarAccessPolicyLink">
+      <li v-if="showAccessPolicyLink">
         <a
-          :href="uiConfiguration?.navbarAccessPolicyLink"
+          :href="accessPolicyLink"
           class="dropdown-item"
           :style="{ color: uiConfiguration?.navbarTextColor }"
         >
           <i class="bi bi-clipboard-check" />
-          {{ uiConfiguration?.navbarAccessPolicyText }}
+          {{ accessPolicyText }}
         </a>
       </li>
       <li>
@@ -176,6 +164,40 @@ const returnAcronymOfName = computed(() => {
     initials = words[0][0].toUpperCase() + ' ' + words[words.length - 1][0].toUpperCase()
   }
   return initials
+})
+
+const privacyPolicyLink = computed(() => {
+  return (
+    uiConfiguration.value?.navbarPrivacyPolicyLink ||
+    uiConfigurationFooter.value?.footerPrivacyPolicyLink
+  )
+})
+
+const privacyPolicyText = computed(() => {
+  return (
+    uiConfiguration.value?.navbarPrivacyPolicyText ||
+    uiConfigurationFooter.value?.footerPrivacyPolicyText
+  )
+})
+
+const showPrivacyPolicyLink = computed(() => {
+  return Boolean(privacyPolicyLink.value && privacyPolicyText.value)
+})
+
+const accessPolicyLink = computed(() => {
+  return uiConfiguration.value?.navbarAccessPolicyLink
+})
+
+const accessPolicyText = computed(() => {
+  return uiConfiguration.value?.navbarAccessPolicyText
+})
+
+const showAccessPolicyLink = computed(() => {
+  return Boolean(accessPolicyLink.value && accessPolicyText.value)
+})
+
+const showLegalLinksSection = computed(() => {
+  return showPrivacyPolicyLink.value || showAccessPolicyLink.value
 })
 
 function signOutOidc() {


### PR DESCRIPTION
### Description:
This pull request updates both the backend and frontend to improve how privacy and access policy links are managed and displayed. The backend migration corrects default values for privacy and access policy URLs, ensuring no unwanted default links are set. The frontend is refactored to consistently compute and display these links, simplifying the logic and making the UI more robust against missing or empty values.

**Backend database migration:**

* The default value for `footerPrivacyPolicyLink` is cleared if it was set to the old BBMRI-ERIC access policy PDF, ensuring no outdated default link is shown.
* The `navbarPrivacyPolicyLink` is set to match the current value of `footerPrivacyPolicyLink`, inheriting any customizations.
* The `navbarAccessPolicyLink` is always set to be empty, removing any default URL.

**Frontend logic and UI improvements:**

* In `FooterComp.vue`, the logic for displaying the privacy policy link is centralized: a computed property, `privacyPolicyLink`, selects the appropriate URL, and `showPrivacyPolicyLink` ensures the link is only shown when both the visibility flag and a URL are present. [[1]](diffhunk://#diff-55cfd12e01785b4b994fe65088de29e68303f94ef1fe13dacc4f7c5b4a4b0c65R232-R244) [[2]](diffhunk://#diff-55cfd12e01785b4b994fe65088de29e68303f94ef1fe13dacc4f7c5b4a4b0c65L118-R122)
* In `ProfileSettings.vue`, similar computed properties (`privacyPolicyLink`, `accessPolicyLink`, and corresponding `show*` flags) are introduced for consistent and simplified handling of legal links in the user profile dropdown. [[1]](diffhunk://#diff-41b43065a35a5687fb0b475dc9542ec0acc5ab88edd7cb40154d3399c31205dcR172-R194) [[2]](diffhunk://#diff-41b43065a35a5687fb0b475dc9542ec0acc5ab88edd7cb40154d3399c31205dcL106-R99) [[3]](diffhunk://#diff-41b43065a35a5687fb0b475dc9542ec0acc5ab88edd7cb40154d3399c31205dcL81-R86)

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
