### PR TITLE
feat: webhook concurrency and transaction improvements

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryDispatcher.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryDispatcher.java
@@ -1,0 +1,33 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ * Submits a single webhook delivery as an independent async task on the dedicated virtual-thread
+ * executor. One task is created per active webhook endpoint so that a slow or unreachable endpoint
+ * does not block delivery to others.
+ */
+@Component
+@RequiredArgsConstructor
+class WebhookDeliveryDispatcher {
+
+  private final WebhookService webhookService;
+
+  /**
+   * Schedules the delivery of a webhook event to the specified endpoint asynchronously.
+   *
+   * @param webhookId the id of the target webhook
+   * @param payload the JSON payload to deliver
+   * @param eventType the event type header for the delivery
+   * @param occurredAt the event timestamp to include as a header
+   */
+  @Async("webhookDeliveryExecutor")
+  void scheduleDelivery(
+      Long webhookId, String payload, WebhookEventType eventType, Instant occurredAt) {
+    webhookService.deliver(payload, eventType, webhookId, occurredAt);
+  }
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryExecutorConfig.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryExecutorConfig.java
@@ -1,0 +1,16 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Provides the executor used for async per-endpoint webhook delivery tasks. */
+@Configuration
+class WebhookDeliveryExecutorConfig {
+
+  @Bean(name = "webhookDeliveryExecutor")
+  Executor webhookDeliveryExecutor() {
+    return Executors.newVirtualThreadPerTaskExecutor();
+  }
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryPersister.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryPersister.java
@@ -1,0 +1,26 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+class WebhookDeliveryPersister {
+
+  private final WebhookRepository webhookRepository;
+  private final ModelMapper modelMapper;
+
+  @Transactional
+  DeliveryDTO persist(Long webhookId, Delivery delivery) {
+    Webhook webhook =
+        webhookRepository
+            .findById(webhookId)
+            .orElseThrow(() -> new EntityNotFoundException(webhookId));
+    webhook.addDelivery(delivery);
+    webhook = webhookRepository.saveAndFlush(webhook);
+    return modelMapper.map(webhook.getDeliveries().get(0), DeliveryDTO.class);
+  }
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.bbmri_eric.negotiator.webhook.event.WebhookEventEnvelope;
 import eu.bbmri_eric.negotiator.webhook.event.WebhookEventMapper;
+import java.util.List;
 import lombok.extern.apachecommons.CommonsLog;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.scheduling.annotation.Async;
@@ -11,9 +12,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
- * Listens for specific application events and dispatches them to active webhooks. This listener
- * serializes mapped webhook envelopes and delivers them to all configured webhooks using the {@link
- * WebhookService}.
+ * Listens for supported application events and schedules per-endpoint webhook deliveries. After a
+ * transaction commits, this listener maps the event, serializes the payload, and submits an
+ * independent async task for each active webhook via {@link WebhookDeliveryDispatcher}, enabling
+ * concurrent delivery so a slow or unreachable endpoint does not block others.
  */
 @Component
 @CommonsLog
@@ -21,18 +23,22 @@ class WebhookEventListener {
   private final WebhookService webhookService;
   private final ObjectMapper objectMapper;
   private final WebhookEventMapper webhookEventMapper;
+  private final WebhookDeliveryDispatcher webhookDeliveryDispatcher;
 
   WebhookEventListener(
       WebhookService webhookService,
       ObjectMapper objectMapper,
-      WebhookEventMapper webhookEventMapper) {
+      WebhookEventMapper webhookEventMapper,
+      WebhookDeliveryDispatcher webhookDeliveryDispatcher) {
     this.webhookService = webhookService;
     this.objectMapper = objectMapper;
     this.webhookEventMapper = webhookEventMapper;
+    this.webhookDeliveryDispatcher = webhookDeliveryDispatcher;
   }
 
   /**
-   * Handles application events asynchronously and dispatches them to webhooks if supported.
+   * Handles application events asynchronously and dispatches them to webhooks if supported. Runs
+   * after the transaction commits to ensure all data is visible in the database.
    *
    * @param event the application event to process
    */
@@ -47,8 +53,11 @@ class WebhookEventListener {
     if (payload == null) {
       return;
     }
-    webhookService.deliverToActiveWebhooks(
-        payload, eventEnvelope.eventType(), eventEnvelope.occurredAt());
+    List<Long> webhookIds = webhookService.getActiveWebhookIds();
+    for (Long webhookId : webhookIds) {
+      webhookDeliveryDispatcher.scheduleDelivery(
+          webhookId, payload, eventEnvelope.eventType(), eventEnvelope.occurredAt());
+    }
   }
 
   private String serializePayload(Object payloadObject) {

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookService.java
@@ -45,9 +45,12 @@ public interface WebhookService {
   void deleteWebhook(Long id);
 
   /**
-   * Creates a new delivery for a given webhook.
+   * Creates a new delivery for a given webhook, using the current time as the occurred-at
+   * timestamp.
    *
    * @param jsonPayload the JSON content for the delivery
+   * @param eventType the event type header for the delivery
+   * @param webhookId the id of the target webhook
    * @return a DTO representing the newly created delivery
    */
   DeliveryDTO deliver(String jsonPayload, WebhookEventType eventType, Long webhookId);
@@ -62,11 +65,21 @@ public interface WebhookService {
   DeliveryDTO redeliver(Long webhookId, String deliveryId);
 
   /**
-   * Creates a new delivery for all active webhooks with an event type header.
+   * Creates a new delivery for a given webhook with an explicit occurred-at timestamp.
    *
    * @param jsonPayload the JSON content for the delivery
-   * @param eventType the event type to send as a header
-   * @param occurredAt the event timestamp to send as a header
+   * @param eventType the event type header for the delivery
+   * @param webhookId the id of the target webhook
+   * @param occurredAt the event timestamp to include as a header
+   * @return a DTO representing the newly created delivery
    */
-  void deliverToActiveWebhooks(String jsonPayload, WebhookEventType eventType, Instant occurredAt);
+  DeliveryDTO deliver(
+      String jsonPayload, WebhookEventType eventType, Long webhookId, Instant occurredAt);
+
+  /**
+   * Returns the ids of all currently active webhooks.
+   *
+   * @return a list of active webhook ids
+   */
+  List<Long> getActiveWebhookIds();
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImpl.java
@@ -94,14 +94,7 @@ public class WebhookServiceImpl implements WebhookService {
 
   @Override
   public DeliveryDTO deliver(String jsonPayload, WebhookEventType eventType, Long webhookId) {
-    if (!JSONUtils.isJSONValid(jsonPayload)) {
-      throw new IllegalArgumentException("Content is not a valid JSON");
-    }
-
-    Webhook webhook = getWebhook(webhookId);
-    RestTemplate restTemplate =
-        webhook.isSslVerification() ? secureRestTemplate : insecureRestTemplate;
-    return deliverWebhook(jsonPayload, restTemplate, webhook, eventType, Instant.now(), null);
+    return deliver(jsonPayload, eventType, webhookId, Instant.now());
   }
 
   @Override
@@ -135,17 +128,21 @@ public class WebhookServiceImpl implements WebhookService {
   }
 
   @Override
-  public void deliverToActiveWebhooks(
-      String jsonPayload, WebhookEventType eventType, Instant occurredAt) {
+  public DeliveryDTO deliver(
+      String jsonPayload, WebhookEventType eventType, Long webhookId, Instant occurredAt) {
     if (!JSONUtils.isJSONValid(jsonPayload)) {
       throw new IllegalArgumentException("Content is not a valid JSON");
     }
-    List<Webhook> webhooks = webhookRepository.findByActiveTrue();
-    for (Webhook webhook : webhooks) {
-      RestTemplate restTemplate =
-          webhook.isSslVerification() ? secureRestTemplate : insecureRestTemplate;
-      deliverWebhook(jsonPayload, restTemplate, webhook, eventType, occurredAt, null);
-    }
+    Webhook webhook = getWebhook(webhookId);
+    RestTemplate restTemplate =
+        webhook.isSslVerification() ? secureRestTemplate : insecureRestTemplate;
+    return deliverWebhook(jsonPayload, restTemplate, webhook, eventType, occurredAt, null);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<Long> getActiveWebhookIds() {
+    return webhookRepository.findByActiveTrue().stream().map(Webhook::getId).toList();
   }
 
   private @NonNull Webhook getWebhook(Long webhookId) {

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImpl.java
@@ -3,7 +3,6 @@ package eu.bbmri_eric.negotiator.webhook;
 import eu.bbmri_eric.negotiator.common.JSONUtils;
 import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
 import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
-import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotNull;
 import java.net.SocketTimeoutException;
 import java.time.Instant;
@@ -19,6 +18,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.ResourceAccessException;
@@ -32,6 +32,7 @@ public class WebhookServiceImpl implements WebhookService {
   private final WebhookRepository webhookRepository;
   private final DeliveryRepository deliveryRepository;
   private final ModelMapper modelMapper;
+  private final WebhookDeliveryPersister webhookDeliveryPersister;
   private final RestTemplate secureRestTemplate;
   private final RestTemplate insecureRestTemplate;
 
@@ -39,11 +40,13 @@ public class WebhookServiceImpl implements WebhookService {
       WebhookRepository webhookRepository,
       DeliveryRepository deliveryRepository,
       ModelMapper modelMapper,
+      WebhookDeliveryPersister webhookDeliveryPersister,
       @Qualifier("secureWebhookRestTemplate") RestTemplate secureRestTemplate,
       @Qualifier("insecureWebhookRestTemplate") RestTemplate insecureRestTemplate) {
     this.webhookRepository = webhookRepository;
     this.deliveryRepository = deliveryRepository;
     this.modelMapper = modelMapper;
+    this.webhookDeliveryPersister = webhookDeliveryPersister;
     this.secureRestTemplate = secureRestTemplate;
     this.insecureRestTemplate = insecureRestTemplate;
   }
@@ -56,7 +59,7 @@ public class WebhookServiceImpl implements WebhookService {
   }
 
   @Override
-  @Transactional
+  @Transactional(readOnly = true)
   public WebhookResponseDTO getWebhookById(Long id) {
     Webhook webhook =
         webhookRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(id));
@@ -64,7 +67,7 @@ public class WebhookServiceImpl implements WebhookService {
   }
 
   @Override
-  @Transactional
+  @Transactional(readOnly = true)
   public List<WebhookResponseDTO> getAllWebhooks() {
     List<Webhook> webhooks = webhookRepository.findAll();
     return webhooks.stream()
@@ -90,7 +93,6 @@ public class WebhookServiceImpl implements WebhookService {
   }
 
   @Override
-  @Transactional
   public DeliveryDTO deliver(String jsonPayload, WebhookEventType eventType, Long webhookId) {
     if (!JSONUtils.isJSONValid(jsonPayload)) {
       throw new IllegalArgumentException("Content is not a valid JSON");
@@ -133,7 +135,6 @@ public class WebhookServiceImpl implements WebhookService {
   }
 
   @Override
-  @Transactional
   public void deliverToActiveWebhooks(
       String jsonPayload, WebhookEventType eventType, Instant occurredAt) {
     if (!JSONUtils.isJSONValid(jsonPayload)) {
@@ -180,7 +181,7 @@ public class WebhookServiceImpl implements WebhookService {
       delivery = new Delivery(jsonPayload, null, parseErrorMessage(ex), eventType);
     }
     delivery.setRedeliveryOfDeliveryId(redeliveryOfDeliveryId);
-    return persistDelivery(webhook, delivery);
+    return webhookDeliveryPersister.persist(webhook.getId(), delivery);
   }
 
   private Delivery mapTransportException(
@@ -194,12 +195,6 @@ public class WebhookServiceImpl implements WebhookService {
       return new Delivery(jsonPayload, null, SSL_VALIDATION_ERROR_MESSAGE, eventType);
     }
     return new Delivery(jsonPayload, null, parseErrorMessage(ex), eventType);
-  }
-
-  private DeliveryDTO persistDelivery(Webhook webhook, Delivery delivery) {
-    webhook.addDelivery(delivery);
-    webhook = webhookRepository.saveAndFlush(webhook);
-    return modelMapper.map(webhook.getDeliveries().get(0), DeliveryDTO.class);
   }
 
   private static int postWebhook(

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImpl.java
@@ -3,12 +3,12 @@ package eu.bbmri_eric.negotiator.webhook;
 import eu.bbmri_eric.negotiator.common.JSONUtils;
 import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
 import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
-import jakarta.validation.constraints.NotNull;
 import java.net.SocketTimeoutException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
 import javax.net.ssl.SSLException;
+import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hc.client5.http.ConnectTimeoutException;
@@ -148,7 +148,7 @@ public class WebhookServiceImpl implements WebhookService {
     }
   }
 
-  private @NotNull Webhook getWebhook(Long webhookId) {
+  private @NonNull Webhook getWebhook(Long webhookId) {
     Webhook webhook =
         webhookRepository
             .findById(webhookId)
@@ -205,8 +205,8 @@ public class WebhookServiceImpl implements WebhookService {
         .value();
   }
 
-  private static @NotNull HttpEntity<String> buildHttpEntity(
-      String jsonPayload, @NotNull WebhookEventType eventType, @NotNull Instant occurredAt) {
+  private static @NonNull HttpEntity<String> buildHttpEntity(
+      String jsonPayload, @NonNull WebhookEventType eventType, @NonNull Instant occurredAt) {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
     headers.add(WebhookHeaders.EVENT_TYPE, eventType.value());

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookDeliveryTransactionBoundaryIntegrationTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookDeliveryTransactionBoundaryIntegrationTest.java
@@ -1,0 +1,104 @@
+package eu.bbmri_eric.negotiator.integration.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import eu.bbmri_eric.negotiator.util.IntegrationTest;
+import eu.bbmri_eric.negotiator.webhook.DeliveryDTO;
+import eu.bbmri_eric.negotiator.webhook.Webhook;
+import eu.bbmri_eric.negotiator.webhook.WebhookRepository;
+import eu.bbmri_eric.negotiator.webhook.WebhookService;
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+@IntegrationTest
+@WireMockTest
+@TestPropertySource(
+    properties = {
+      "spring.datasource.hikari.maximum-pool-size=2",
+      "spring.datasource.hikari.minimum-idle=1",
+      "spring.datasource.hikari.connection-timeout=500"
+    })
+class WebhookDeliveryTransactionBoundaryIntegrationTest {
+
+  @Autowired private WebhookRepository webhookRepository;
+
+  @Autowired private WebhookService webhookService;
+
+  @BeforeEach
+  void setUp() {
+    webhookRepository.deleteAll();
+  }
+
+  @Test
+  void deliver_withTwoSlowDeliveries_allowsConcurrentRepositoryRead(
+      WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+    String baseUrl = wireMockRuntimeInfo.getHttpBaseUrl();
+    Webhook firstWebhook = webhookRepository.save(new Webhook(baseUrl + "/slow-one", true, true));
+    Webhook secondWebhook = webhookRepository.save(new Webhook(baseUrl + "/slow-two", true, true));
+
+    stubFor(post(urlEqualTo("/slow-one")).willReturn(ok().withFixedDelay(2500).withBody("ok")));
+    stubFor(post(urlEqualTo("/slow-two")).willReturn(ok().withFixedDelay(2500).withBody("ok")));
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(3)) {
+      Future<DeliveryDTO> firstDeliveryFuture =
+          executor.submit(
+              () ->
+                  webhookService.deliver(
+                      "{\"delivery\":1}", WebhookEventType.CUSTOM, firstWebhook.getId()));
+      Future<DeliveryDTO> secondDeliveryFuture =
+          executor.submit(
+              () ->
+                  webhookService.deliver(
+                      "{\"delivery\":2}", WebhookEventType.CUSTOM, secondWebhook.getId()));
+
+      await("both delivery attempts")
+          .atMost(Duration.ofSeconds(2))
+          .untilAsserted(
+              () -> {
+                verify(1, postRequestedFor(urlEqualTo("/slow-one")));
+                verify(1, postRequestedFor(urlEqualTo("/slow-two")));
+              });
+
+      long startNanos = System.nanoTime();
+      Future<Long> countFuture = executor.submit(() -> Long.valueOf(webhookRepository.count()));
+      Long count = countFuture.get(1, TimeUnit.SECONDS);
+      long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+
+      assertTrue(count >= 2L);
+      assertTrue(
+          elapsedMillis < 1000,
+          "Concurrent DB read should not wait for slow outbound webhook HTTP");
+
+      DeliveryDTO firstDelivery = firstDeliveryFuture.get(6, TimeUnit.SECONDS);
+      DeliveryDTO secondDelivery = secondDeliveryFuture.get(6, TimeUnit.SECONDS);
+
+      assertEquals(200, firstDelivery.getHttpStatusCode());
+      assertNull(firstDelivery.getErrorMessage());
+      assertTrue(StringUtils.isNotBlank(firstDelivery.getId()));
+
+      assertEquals(200, secondDelivery.getHttpStatusCode());
+      assertNull(secondDelivery.getErrorMessage());
+      assertTrue(StringUtils.isNotBlank(secondDelivery.getId()));
+    }
+  }
+}

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryDispatcherTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryDispatcherTest.java
@@ -1,0 +1,35 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import static org.mockito.Mockito.verify;
+
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WebhookDeliveryDispatcherTest {
+
+  @Mock private WebhookService webhookService;
+
+  private WebhookDeliveryDispatcher dispatcher;
+
+  @BeforeEach
+  void setUp() {
+    dispatcher = new WebhookDeliveryDispatcher(webhookService);
+  }
+
+  @Test
+  void scheduleDelivery_delegatesToWebhookService() {
+    Instant occurredAt = Instant.parse("2026-01-01T00:00:00Z");
+
+    dispatcher.scheduleDelivery(
+        1L, "{\"key\":\"value\"}", WebhookEventType.NEGOTIATION_INFO_UPDATED, occurredAt);
+
+    verify(webhookService)
+        .deliver("{\"key\":\"value\"}", WebhookEventType.NEGOTIATION_INFO_UPDATED, 1L, occurredAt);
+  }
+}

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryPersisterTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryPersisterTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,7 @@ class WebhookDeliveryPersisterTest {
     Long webhookId = 1L;
     Webhook webhook = new Webhook("https://example.com/webhook", true, true);
     webhook.setId(webhookId);
-    Delivery delivery = new Delivery("{\"test\":\"ok\"}", 200);
+    Delivery delivery = new Delivery("{\"test\":\"ok\"}", 200, WebhookEventType.CUSTOM);
     DeliveryDTO expected = new DeliveryDTO();
 
     when(webhookRepository.findById(webhookId)).thenReturn(Optional.of(webhook));
@@ -55,7 +56,8 @@ class WebhookDeliveryPersisterTest {
   @Test
   void persist_whenWebhookDoesNotExist_throwsEntityNotFoundException() {
     Long webhookId = 99L;
-    Delivery delivery = new Delivery("{\"test\":\"not-found\"}", 500, "error");
+    Delivery delivery =
+        new Delivery("{\"test\":\"not-found\"}", 500, "error", WebhookEventType.CUSTOM);
 
     when(webhookRepository.findById(webhookId)).thenReturn(Optional.empty());
 

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryPersisterTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryPersisterTest.java
@@ -1,0 +1,65 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+@ExtendWith(MockitoExtension.class)
+class WebhookDeliveryPersisterTest {
+
+  @Mock private WebhookRepository webhookRepository;
+
+  @Mock private ModelMapper modelMapper;
+
+  private WebhookDeliveryPersister webhookDeliveryPersister;
+
+  @BeforeEach
+  void setUp() {
+    webhookDeliveryPersister = new WebhookDeliveryPersister(webhookRepository, modelMapper);
+  }
+
+  @Test
+  void persist_whenWebhookExists_addsDeliveryAndReturnsMappedDto() {
+    Long webhookId = 1L;
+    Webhook webhook = new Webhook("https://example.com/webhook", true, true);
+    webhook.setId(webhookId);
+    Delivery delivery = new Delivery("{\"test\":\"ok\"}", 200);
+    DeliveryDTO expected = new DeliveryDTO();
+
+    when(webhookRepository.findById(webhookId)).thenReturn(Optional.of(webhook));
+    when(webhookRepository.saveAndFlush(webhook)).thenReturn(webhook);
+    when(modelMapper.map(any(Delivery.class), eq(DeliveryDTO.class))).thenReturn(expected);
+
+    DeliveryDTO actual = webhookDeliveryPersister.persist(webhookId, delivery);
+
+    assertSame(expected, actual);
+    assertEquals(1, webhook.getDeliveries().size());
+    assertEquals(webhookId, webhook.getDeliveries().get(0).getWebhookId());
+    verify(webhookRepository).findById(webhookId);
+    verify(webhookRepository).saveAndFlush(webhook);
+  }
+
+  @Test
+  void persist_whenWebhookDoesNotExist_throwsEntityNotFoundException() {
+    Long webhookId = 99L;
+    Delivery delivery = new Delivery("{\"test\":\"not-found\"}", 500, "error");
+
+    when(webhookRepository.findById(webhookId)).thenReturn(Optional.empty());
+
+    assertThrows(
+        EntityNotFoundException.class, () -> webhookDeliveryPersister.persist(webhookId, delivery));
+  }
+}

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListenerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListenerTest.java
@@ -12,6 +12,7 @@ import eu.bbmri_eric.negotiator.webhook.event.WebhookEventEnvelope;
 import eu.bbmri_eric.negotiator.webhook.event.WebhookEventMapper;
 import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,17 +26,17 @@ import org.springframework.context.ApplicationEvent;
 class WebhookEventListenerTest {
 
   @Mock private WebhookService webhookService;
-
   @Mock private ObjectMapper objectMapper;
-
   @Mock private WebhookEventMapper webhookEventMapper;
+  @Mock private WebhookDeliveryDispatcher webhookDeliveryDispatcher;
 
   private WebhookEventListener webhookEventListener;
 
   @BeforeEach
   void setUp() {
     webhookEventListener =
-        new WebhookEventListener(webhookService, objectMapper, webhookEventMapper);
+        new WebhookEventListener(
+            webhookService, objectMapper, webhookEventMapper, webhookDeliveryDispatcher);
   }
 
   @Test
@@ -47,7 +48,7 @@ class WebhookEventListenerTest {
     webhookEventListener.onWebhookEvent(unsupportedEvent);
 
     verify(objectMapper, never()).writeValueAsString(any());
-    verify(webhookService, never()).deliverToActiveWebhooks(any(), any(), any());
+    verify(webhookDeliveryDispatcher, never()).scheduleDelivery(any(), any(), any(), any());
   }
 
   @Test
@@ -65,11 +66,12 @@ class WebhookEventListenerTest {
 
     webhookEventListener.onWebhookEvent(event);
 
-    verify(webhookService, never()).deliverToActiveWebhooks(any(), any(), any());
+    verify(webhookDeliveryDispatcher, never()).scheduleDelivery(any(), any(), any(), any());
   }
 
   @Test
-  void onWebhookEvent_whenEventIsDispatched_shouldDeliverWebhook() throws JsonProcessingException {
+  void onWebhookEvent_whenEventIsDispatched_schedulesOneDeliveryPerActiveWebhook()
+      throws JsonProcessingException {
     InformationSubmissionEvent event = new InformationSubmissionEvent(this, "negotiation-1");
     WebhookEventEnvelope<Map<String, String>> envelope =
         new WebhookEventEnvelope<>(
@@ -79,13 +81,39 @@ class WebhookEventListenerTest {
     when(webhookEventMapper.map(event)).thenReturn(Optional.of(envelope));
     when(objectMapper.writeValueAsString(envelope.data()))
         .thenReturn("{\"negotiationId\":\"negotiation-1\"}");
+    when(webhookService.getActiveWebhookIds()).thenReturn(List.of(1L, 2L));
 
     webhookEventListener.onWebhookEvent(event);
 
-    verify(webhookService)
-        .deliverToActiveWebhooks(
+    verify(webhookDeliveryDispatcher)
+        .scheduleDelivery(
+            1L,
             "{\"negotiationId\":\"negotiation-1\"}",
             WebhookEventType.NEGOTIATION_INFO_UPDATED,
             Instant.parse("2026-01-01T00:00:00Z"));
+    verify(webhookDeliveryDispatcher)
+        .scheduleDelivery(
+            2L,
+            "{\"negotiationId\":\"negotiation-1\"}",
+            WebhookEventType.NEGOTIATION_INFO_UPDATED,
+            Instant.parse("2026-01-01T00:00:00Z"));
+  }
+
+  @Test
+  void onWebhookEvent_whenNoActiveWebhooks_schedulesNoDeliveries() throws JsonProcessingException {
+    InformationSubmissionEvent event = new InformationSubmissionEvent(this, "negotiation-1");
+    WebhookEventEnvelope<Map<String, String>> envelope =
+        new WebhookEventEnvelope<>(
+            WebhookEventType.NEGOTIATION_INFO_UPDATED,
+            Instant.parse("2026-01-01T00:00:00Z"),
+            Map.of("negotiationId", "negotiation-1"));
+    when(webhookEventMapper.map(event)).thenReturn(Optional.of(envelope));
+    when(objectMapper.writeValueAsString(envelope.data()))
+        .thenReturn("{\"negotiationId\":\"negotiation-1\"}");
+    when(webhookService.getActiveWebhookIds()).thenReturn(List.of());
+
+    webhookEventListener.onWebhookEvent(event);
+
+    verify(webhookDeliveryDispatcher, never()).scheduleDelivery(any(), any(), any(), any());
   }
 }


### PR DESCRIPTION
### Description:
This pull request introduces a significant refactor of the webhook delivery mechanism to enable truly concurrent, per-endpoint webhook delivery using independent async tasks. The changes decouple the scheduling and persistence of webhook deliveries, improve testability, and add new integration and unit tests for the new components.

**Key changes include:**

### Concurrent Webhook Delivery

* Introduced the `WebhookDeliveryDispatcher` component, which schedules each webhook delivery as an independent async task using a dedicated virtual-thread executor, ensuring slow or unreachable endpoints do not block others. (`WebhookDeliveryDispatcher.java` [[1]](diffhunk://#diff-09266c6b538690b1d5c45025a393c9ff9f8669577cedb5e001f72cc4ae02335aR1-R33) `WebhookDeliveryExecutorConfig.java` [[2]](diffhunk://#diff-83c705548adb75c39b9a180517f11736726a073bc2c1c4cfba527639c2fbd922R1-R16)
* Refactored `WebhookEventListener` to use `WebhookDeliveryDispatcher` for per-endpoint delivery, replacing the previous approach that delivered to all endpoints sequentially. (`WebhookEventListener.java` [[1]](diffhunk://#diff-abdc6b72c47075e89db6a95ac74cfe9ee785205fe8daced200874751555043d6R7-R41) [[2]](diffhunk://#diff-abdc6b72c47075e89db6a95ac74cfe9ee785205fe8daced200874751555043d6L50-R60)

### Service Layer and Persistence Refactoring

* Updated the `WebhookService` interface and its implementation to support per-endpoint delivery with explicit control over the event timestamp, and to provide a method for retrieving active webhook IDs. (`WebhookService.java` [[1]](diffhunk://#diff-cad39a2c9803f1593f123d4cc2b5828f898eee5f31a69fdb24b15c235e4a2695L48-R53) [[2]](diffhunk://#diff-cad39a2c9803f1593f123d4cc2b5828f898eee5f31a69fdb24b15c235e4a2695L65-R84); `WebhookServiceImpl.java` [[3]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L6-R11) [[4]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147R21) [[5]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147R35-R49) [[6]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L59-R70) [[7]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L93-R97) [[8]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L136-R148) [[9]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L183-R181) [[10]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L199-L204) [[11]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L213-R206)
* Extracted delivery persistence logic into a new `WebhookDeliveryPersister` component for better separation of concerns and testability. (`WebhookDeliveryPersister.java` [backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryPersister.javaR1-R27](diffhunk://#diff-ebf94e6bfe5695c46a68c49cf7055e357cf75d4173c6379749140394f6932e5fR1-R27))

### Testing Improvements

* Added a new integration test to verify that concurrent webhook deliveries do not block database reads, even when endpoints are slow. (`WebhookDeliveryTransactionBoundaryIntegrationTest.java` [backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookDeliveryTransactionBoundaryIntegrationTest.javaR1-R94](diffhunk://#diff-ccb5129ecad2b7da2bf5b31ec14531d1027687fda9e85c615cd5ca6673cd4457R1-R94))
* Added a unit test for `WebhookDeliveryDispatcher` to ensure it delegates delivery tasks correctly. (`WebhookDeliveryDispatcherTest.java` [backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryDispatcherTest.javaR1-R35](diffhunk://#diff-9f744784ec1d905068f87a4d3bb05fdf63149f6ebb4caf361940698a8a9d31c3R1-R35))

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
