### PR TITLE
docs: update default branch for vitepress edit button

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -58,7 +58,7 @@ export default defineConfig({
             provider: 'local'
         },
         editLink: {
-            pattern: 'https://github.com/bbmri-eric/negotiator/edit/main/docs/:path',
+            pattern: 'https://github.com/bbmri-eric/negotiator/edit/master/docs/:path',
             text: 'Edit this page on GitHub'
         },
         sidebar: [


### PR DESCRIPTION
### Description:

The "Edit this page on GitHub" link in the user documentation fails because it is referencing the `main` default branch. This PR fixes the issue by changing the link pattern to use `master` as the referenced branch.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
