### PR TITLE
fix: silent redirect uri replacement

### DIFF
--- a/frontend/src/config/oidc.js
+++ b/frontend/src/config/oidc.js
@@ -19,7 +19,7 @@ const prodSettings = {
   post_logout_redirect_uri: 'LOGOUT_URI_PLACEHOLDER',
   response_type: 'code',
   automaticSilentRenew: true,
-  silentRedirectUri: 'SILENT_REDIRECT_URI_PLACEHOLDER',
+  silentRedirectUri: 'SILENT_REDIRECT_URL_PLACEHOLDER',
 }
 
 let oidcSettings

--- a/frontend/start.sh
+++ b/frontend/start.sh
@@ -6,12 +6,14 @@ for file in assets/*.js;
  do
   echo "Processing $file ..."
 
+  # Make sure that placeholders are not part of other placeholders to avoid accidental replacements.
+  # For example, ONE_PLACEHOLDER could affect ANOTHER_ONE_PLACEHOLDER
   sed -i -e "s|AUTH_URL_PLACEHOLDER|${AUTH_URL:-default_auth_url}|g" \
          -e "s|CLIENT_ID_PLACEHOLDER|${CLIENT_ID:-default_client_id}|g" \
          -e "s|REDIRECT_URI_PLACEHOLDER|${REDIRECT_URI:-default_redirect_uri}|g" \
          -e "s|SCOPES_PLACEHOLDER|${SCOPES:-default_scopes}|g" \
          -e "s|LOGOUT_URI_PLACEHOLDER|${LOGOUT_URI:-default_logout_uri}|g" \
-         -e "s|SILENT_REDIRECT_URI_PLACEHOLDER|${SILENT_REDIRECT_URI:-default_silent_redirect_uri}|g" \
+         -e "s|SILENT_REDIRECT_URL_PLACEHOLDER|${SILENT_REDIRECT_URI:-default_silent_redirect_uri}|g" \
          -e "s|RESOURCES_PLACEHOLDER|${API_RESOURCES:-default_resources}|g" \
          -e "s|MATOMO_HOST_PLACEHOLDER|${MATOMO_HOST:-default_matomo_host}|g" \
          -e "s|MATOMO_SITE_ID_PLACEHOLDER|${MATOMO_SITE_ID:-default_site_id}|g" \


### PR DESCRIPTION
### Description:

Fixing an issue where the `REDIRECT_URL_PLACEHOLDER` value was inserted inserted in `SILENT_REDIRECT_URL_PLACEHOLDER`, ending up with a silent redirect uri like `SILENT_https://...`. Renaming this placeholder prevents the undesired injection of the `REDIRECT_URL_PLACEHOLDER` value.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
