### PR TITLE
fix: oidc crash

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -69,6 +69,8 @@ services:
   oidc-server-mock:
     container_name: oidc-server-mock
     image: ghcr.io/soluto/oidc-server-mock:0.9.2
+    restart: always
+    platform: linux/amd64
     ports:
       - '4011:8080'
     environment:


### PR DESCRIPTION
### Description:

Describe the bug
```
assertion failed [block != nullptr]: BasicBlock requested for unrecognized address
(BuilderBase.h:550 block_for_offset)
```
How to reproduce
run BE/FE/ oidc Docker, on first login, the oidc Docker container will shut down on mac

What happens
This is a .NET 8 JIT crash — happens on Apple Silicon (M1/M2/M3) Mac when running the oidc-server-mock image under Rosetta emulation (the image only has an amd64 build, not arm64). The crash is triggered during JIT compilation of certain code paths, like the HTTPS redirect middleware.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
