### PR TITLE
feat: replace custom webhook events with consistant ping

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookController.java
@@ -1,8 +1,6 @@
 package eu.bbmri_eric.negotiator.webhook;
 
-import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -76,19 +74,11 @@ public class WebhookController {
   }
 
   @Operation(
-      summary = "Add a delivery to a webhook",
-      description = "Adds a new delivery to the specified webhook and returns the response")
-  @PostMapping(value = "/{id}/deliveries")
-  public EntityModel<DeliveryDTO> addDelivery(
-      @PathVariable Long id,
-      @Valid
-          @RequestBody
-          @Schema(
-              description = "Content to deliver",
-              example = "{\"test\":\"yes\"}",
-              type = "object")
-          String content) {
-    DeliveryDTO dto = webhookService.deliver(content, WebhookEventType.CUSTOM, id);
+      summary = "Send a ping delivery to a webhook",
+      description = "Sends a predefined ping payload to the specified webhook")
+  @PostMapping(value = "/{id}/ping")
+  public EntityModel<DeliveryDTO> ping(@PathVariable Long id) {
+    DeliveryDTO dto = webhookService.ping(id);
     return EntityModel.of(dto);
   }
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryDispatcher.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryDispatcher.java
@@ -1,7 +1,6 @@
 package eu.bbmri_eric.negotiator.webhook;
 
 import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
-import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -23,11 +22,9 @@ class WebhookDeliveryDispatcher {
    * @param webhookId the id of the target webhook
    * @param payload the JSON payload to deliver
    * @param eventType the event type header for the delivery
-   * @param occurredAt the event timestamp to include as a header
    */
   @Async("webhookDeliveryExecutor")
-  void scheduleDelivery(
-      Long webhookId, String payload, WebhookEventType eventType, Instant occurredAt) {
-    webhookService.deliver(payload, eventType, webhookId, occurredAt);
+  void scheduleDelivery(Long webhookId, String payload, WebhookEventType eventType) {
+    webhookService.deliver(payload, eventType, webhookId);
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListener.java
@@ -55,8 +55,7 @@ class WebhookEventListener {
     }
     List<Long> webhookIds = webhookService.getActiveWebhookIds();
     for (Long webhookId : webhookIds) {
-      webhookDeliveryDispatcher.scheduleDelivery(
-          webhookId, payload, payloadEnvelope.type(), payloadEnvelope.timestamp());
+      webhookDeliveryDispatcher.scheduleDelivery(webhookId, payload, payloadEnvelope.type());
     }
   }
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookService.java
@@ -1,7 +1,6 @@
 package eu.bbmri_eric.negotiator.webhook;
 
 import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
-import java.time.Instant;
 import java.util.List;
 
 public interface WebhookService {
@@ -45,8 +44,7 @@ public interface WebhookService {
   void deleteWebhook(Long id);
 
   /**
-   * Creates a new delivery for a given webhook, using the current time as the occurred-at
-   * timestamp.
+   * Creates a new delivery for a given webhook.
    *
    * @param jsonPayload the JSON content for the delivery
    * @param eventType the event type header for the delivery
@@ -56,6 +54,14 @@ public interface WebhookService {
   DeliveryDTO deliver(String jsonPayload, WebhookEventType eventType, Long webhookId);
 
   /**
+   * Sends a standardized ping delivery for the given webhook.
+   *
+   * @param webhookId the id of the target webhook
+   * @return a DTO representing the newly created ping delivery
+   */
+  DeliveryDTO ping(Long webhookId);
+
+  /**
    * Creates a manual redelivery for a previously recorded delivery.
    *
    * @param webhookId the owning webhook id
@@ -63,18 +69,6 @@ public interface WebhookService {
    * @return a DTO representing the newly created delivery attempt
    */
   DeliveryDTO redeliver(Long webhookId, String deliveryId);
-
-  /**
-   * Creates a new delivery for a given webhook with an explicit occurred-at timestamp.
-   *
-   * @param jsonPayload the JSON content for the delivery
-   * @param eventType the event type header for the delivery
-   * @param webhookId the id of the target webhook
-   * @param occurredAt the event timestamp to include as a header
-   * @return a DTO representing the newly created delivery
-   */
-  DeliveryDTO deliver(
-      String jsonPayload, WebhookEventType eventType, Long webhookId, Instant occurredAt);
 
   /**
    * Returns the ids of all currently active webhooks.

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImpl.java
@@ -1,7 +1,6 @@
 package eu.bbmri_eric.negotiator.webhook;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.bbmri_eric.negotiator.common.JSONUtils;
 import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
@@ -113,7 +112,22 @@ public class WebhookServiceImpl implements WebhookService {
 
   @Override
   public DeliveryDTO deliver(String jsonPayload, WebhookEventType eventType, Long webhookId) {
-    return deliver(jsonPayload, eventType, webhookId, Instant.now());
+    if (!JSONUtils.isJSONValid(jsonPayload)) {
+      throw new IllegalArgumentException("Content is not a valid JSON");
+    }
+    Webhook webhook = getWebhook(webhookId);
+    RestTemplate restTemplate =
+        webhook.isSslVerification() ? secureRestTemplate : insecureRestTemplate;
+    String webhookMessageId = UUID.randomUUID().toString();
+    return deliverWebhook(jsonPayload, restTemplate, webhook, eventType, null, webhookMessageId);
+  }
+
+  @Override
+  public DeliveryDTO ping(Long webhookId) {
+    Instant occurredAt = Instant.now();
+    var payloadEnvelope = WebhookPayloadEnvelope.ping(webhookId, occurredAt);
+    String payload = serializePayload(payloadEnvelope);
+    return deliver(payload, WebhookEventType.PING, webhookId);
   }
 
   @Override
@@ -140,21 +154,6 @@ public class WebhookServiceImpl implements WebhookService {
         sourceDelivery.getEventType(),
         rootDeliveryId,
         rootDeliveryId);
-  }
-
-  @Override
-  public DeliveryDTO deliver(
-      String jsonPayload, WebhookEventType eventType, Long webhookId, Instant occurredAt) {
-    String payloadToDeliver = toPayloadEnvelopeIfNeeded(jsonPayload, eventType, occurredAt);
-    if (!JSONUtils.isJSONValid(payloadToDeliver)) {
-      throw new IllegalArgumentException("Content is not a valid JSON");
-    }
-    Webhook webhook = getWebhook(webhookId);
-    RestTemplate restTemplate =
-        webhook.isSslVerification() ? secureRestTemplate : insecureRestTemplate;
-    String webhookMessageId = UUID.randomUUID().toString();
-    return deliverWebhook(
-        payloadToDeliver, restTemplate, webhook, eventType, null, webhookMessageId);
   }
 
   @Override
@@ -271,17 +270,11 @@ public class WebhookServiceImpl implements WebhookService {
     return new HttpEntity<>(jsonPayload, headers);
   }
 
-  private String toPayloadEnvelopeIfNeeded(
-      String jsonPayload, @NonNull WebhookEventType eventType, @NonNull Instant occurredAt) {
-    if (eventType != WebhookEventType.CUSTOM) {
-      return jsonPayload;
-    }
-
+  private String serializePayload(Object payloadObject) {
     try {
-      JsonNode customData = objectMapper.readTree(jsonPayload);
-      return objectMapper.writeValueAsString(WebhookPayloadEnvelope.custom(occurredAt, customData));
+      return objectMapper.writeValueAsString(payloadObject);
     } catch (JsonProcessingException ex) {
-      throw new IllegalArgumentException("Content is not a valid JSON", ex);
+      throw new IllegalStateException("Could not serialize webhook payload", ex);
     }
   }
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/PingWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/PingWebhookEvent.java
@@ -1,0 +1,8 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+/**
+ * Webhook data payload for a ping delivery.
+ *
+ * @param webhookId identifier of the target webhook
+ */
+record PingWebhookEvent(Long webhookId) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventType.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventType.java
@@ -7,13 +7,13 @@ import lombok.AllArgsConstructor;
 /** Defines external webhook event type names. */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum WebhookEventType {
-  CUSTOM("custom"),
   NEGOTIATION_ADDED("negotiation.added"),
-  NEGOTIATION_STATE_UPDATED("negotiation.state.updated"),
   NEGOTIATION_INFO_UPDATED("negotiation.info.updated"),
+  NEGOTIATION_POST_ADDED("negotiation.post.added"),
   NEGOTIATION_RESOURCE_ADDED("negotiation.resource.added"),
   NEGOTIATION_RESOURCE_STATE_UPDATED("negotiation.resource.state.updated"),
-  NEGOTIATION_POST_ADDED("negotiation.post.added");
+  NEGOTIATION_STATE_UPDATED("negotiation.state.updated"),
+  PING("ping");
 
   private final String value;
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookPayloadEnvelope.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookPayloadEnvelope.java
@@ -11,8 +11,9 @@ import java.time.Instant;
  */
 public record WebhookPayloadEnvelope<T>(WebhookEventType type, Instant timestamp, T data) {
 
-  /** Creates a custom outbound payload envelope. */
-  public static <T> WebhookPayloadEnvelope<T> custom(Instant occurredAt, T data) {
-    return new WebhookPayloadEnvelope<>(WebhookEventType.CUSTOM, occurredAt, data);
+  /** Creates a ping outbound payload envelope. */
+  public static WebhookPayloadEnvelope<?> ping(Long webhookId, Instant occurredAt) {
+    return new WebhookPayloadEnvelope<>(
+        WebhookEventType.PING, occurredAt, new PingWebhookEvent(webhookId));
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/WebhookControllerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/WebhookControllerTest.java
@@ -198,19 +198,16 @@ public class WebhookControllerTest {
 
   @Test
   @WithMockUser(roles = "ADMIN")
-  void testDeliverSuccess(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+  void testPingSuccess(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
     String url = wmRuntimeInfo.getHttpBaseUrl() + "/test-endpoint";
     Webhook webhook = new Webhook(url, true, true);
     webhook = webhookRepository.save(webhook);
     stubFor(
         post(urlEqualTo("/test-endpoint")).willReturn(aResponse().withStatus(200).withBody("OK")));
-    String payload = objectMapper.writeValueAsString("{\"data\":\"fail\"}");
     mockMvc
         .perform(
-            MockMvcRequestBuilders.post(
-                    String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(payload))
+            MockMvcRequestBuilders.post(String.format("/v3/webhooks/%d/ping", webhook.getId()))
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andDo(print())
         .andExpect(jsonPath("$.httpStatusCode", is(200)))
@@ -219,46 +216,35 @@ public class WebhookControllerTest {
 
   @Test
   @WithMockUser(roles = "ADMIN")
-  void testDeliverInvalidJson(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+  void testDeliverEndpointRemoved_returnsClientError(WireMockRuntimeInfo wmRuntimeInfo)
+      throws Exception {
     String url = wmRuntimeInfo.getHttpBaseUrl() + "/test-endpoint";
-    Webhook webhook = new Webhook(url, true, true);
-    webhook = webhookRepository.save(webhook);
-    String invalidPayload = "Not a JSON";
-    mockMvc
-        .perform(
-            MockMvcRequestBuilders.post(
-                    String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(invalidPayload))
-        .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.detail", is("Content is not a valid JSON")));
-    invalidPayload = "{\"data\"\"fail\"}";
-    mockMvc
-        .perform(
-            MockMvcRequestBuilders.post(
-                    String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(invalidPayload))
-        .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.detail", is("Content is not a valid JSON")));
-  }
+    Webhook webhook = webhookRepository.save(new Webhook(url, true, true));
+    String payload = "{\"data\":\"fail\"}";
 
-  @Test
-  @WithMockUser(roles = "ADMIN")
-  void testDeliverExternalServerError(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-    String url = wmRuntimeInfo.getHttpBaseUrl() + "/test-endpoint";
-    Webhook webhook = new Webhook(url, true, true);
-    webhook = webhookRepository.save(webhook);
-    stubFor(
-        post(urlEqualTo("/test-endpoint"))
-            .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
-    String payload = objectMapper.writeValueAsString("{\"data\":\"fail\"}");
     mockMvc
         .perform(
             MockMvcRequestBuilders.post(
                     String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
+        .andExpect(status().is4xxClientError());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void testPingExternalServerError(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    String url = wmRuntimeInfo.getHttpBaseUrl() + "/test-endpoint";
+    Webhook webhook = new Webhook(url, true, true);
+    webhook = webhookRepository.save(webhook);
+    stubFor(
+        post(urlEqualTo("/test-endpoint"))
+            .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post(String.format("/v3/webhooks/%d/ping", webhook.getId()))
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andDo(print())
         .andExpect(jsonPath("$.httpStatusCode", is(500)))
@@ -267,20 +253,18 @@ public class WebhookControllerTest {
 
   @Test
   @WithMockUser(roles = "ADMIN")
-  void testDeliver_notActive_returns400(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+  void testPing_notActive_returns400(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
     String url = wmRuntimeInfo.getHttpBaseUrl() + "/test-endpoint";
     Webhook webhook = new Webhook(url, true, false);
     webhook = webhookRepository.save(webhook);
     stubFor(
         post(urlEqualTo("/test-endpoint"))
             .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
-    String payload = objectMapper.writeValueAsString("{\"data\":\"fail\"}");
+
     mockMvc
         .perform(
-            MockMvcRequestBuilders.post(
-                    String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(payload))
+            MockMvcRequestBuilders.post(String.format("/v3/webhooks/%d/ping", webhook.getId()))
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest())
         .andExpect(
             jsonPath(
@@ -289,7 +273,7 @@ public class WebhookControllerTest {
 
   @Test
   @WithMockUser(roles = "ADMIN")
-  void testDeliver_active_receivesWebhook(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+  void testPing_active_receivesWebhook(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
     // Build the URL for the WireMock stub endpoint.
     String url = wmRuntimeInfo.getHttpBaseUrl() + "/test-endpoint";
 
@@ -306,25 +290,21 @@ public class WebhookControllerTest {
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                     .withBody("{\"status\":\"received\"}")));
 
-    // Prepare a JSON payload to send.
-    String payload = "{\"data\":\"success\"}";
-
-    // Perform the test delivery request via mockMvc.
+    // Perform the test ping request via mockMvc.
     mockMvc
         .perform(
-            MockMvcRequestBuilders.post(
-                    String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(payload))
+            MockMvcRequestBuilders.post(String.format("/v3/webhooks/%d/ping", webhook.getId()))
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
 
     // Verify that the stub endpoint received a POST request with the expected JSON payload.
     verify(
         postRequestedFor(urlEqualTo("/test-endpoint"))
             .withHeader("Content-Type", equalTo("application/json"))
-            .withRequestBody(matchingJsonPath("$.type", equalTo("custom")))
+            .withRequestBody(matchingJsonPath("$.type", equalTo("ping")))
             .withRequestBody(matchingJsonPath("$.timestamp"))
-            .withRequestBody(matchingJsonPath("$.data.data", equalTo("success"))));
+            .withRequestBody(
+                matchingJsonPath("$.data.webhookId", equalTo(String.valueOf(webhook.getId())))));
 
     var requests = findAll(postRequestedFor(urlEqualTo("/test-endpoint")));
     assertEquals(1, requests.size());
@@ -348,15 +328,11 @@ public class WebhookControllerTest {
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                     .withBody("{\"status\":\"received\"}")));
 
-    String payload = "{\"data\":\"redelivery\"}";
-
     MvcResult firstDeliveryResult =
         mockMvc
             .perform(
-                MockMvcRequestBuilders.post(
-                        String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(payload))
+                MockMvcRequestBuilders.post(String.format("/v3/webhooks/%d/ping", webhook.getId()))
+                    .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -384,9 +360,8 @@ public class WebhookControllerTest {
         2,
         postRequestedFor(urlEqualTo("/test-endpoint"))
             .withHeader("Content-Type", equalTo("application/json"))
-            .withRequestBody(matchingJsonPath("$.type", equalTo("custom")))
-            .withRequestBody(matchingJsonPath("$.timestamp"))
-            .withRequestBody(matchingJsonPath("$.data.data", equalTo("redelivery"))));
+            .withRequestBody(matchingJsonPath("$.type", equalTo("ping")))
+            .withRequestBody(matchingJsonPath("$.timestamp")));
   }
 
   @Test
@@ -414,14 +389,11 @@ public class WebhookControllerTest {
     stubFor(
         post(urlEqualTo("/test-endpoint")).willReturn(aResponse().withStatus(200).withBody("OK")));
 
-    String payload = "{\"data\":\"redelivery\"}";
     MvcResult firstDeliveryResult =
         mockMvc
             .perform(
-                MockMvcRequestBuilders.post(
-                        String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(payload))
+                MockMvcRequestBuilders.post(String.format("/v3/webhooks/%d/ping", webhook.getId()))
+                    .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andReturn();
     String sourceDeliveryId =
@@ -460,15 +432,11 @@ public class WebhookControllerTest {
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                     .withBody("{\"status\":\"received\"}")));
 
-    String payload = "{\"data\":\"redelivery\"}";
-
     MvcResult sourceDeliveryResult =
         mockMvc
             .perform(
-                MockMvcRequestBuilders.post(
-                        String.format("/v3/webhooks/%d/deliveries", webhook.getId()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(payload))
+                MockMvcRequestBuilders.post(String.format("/v3/webhooks/%d/ping", webhook.getId()))
+                    .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -515,9 +483,8 @@ public class WebhookControllerTest {
         3,
         postRequestedFor(urlEqualTo("/test-endpoint"))
             .withHeader("Content-Type", equalTo("application/json"))
-            .withRequestBody(matchingJsonPath("$.type", equalTo("custom")))
-            .withRequestBody(matchingJsonPath("$.timestamp"))
-            .withRequestBody(matchingJsonPath("$.data.data", equalTo("redelivery"))));
+            .withRequestBody(matchingJsonPath("$.type", equalTo("ping")))
+            .withRequestBody(matchingJsonPath("$.timestamp")));
   }
 
   @Test

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookDeliverySslIntegrationTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookDeliverySslIntegrationTest.java
@@ -70,18 +70,14 @@ public class WebhookDeliverySslIntegrationTest {
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                     .withBody("{\"status\":\"received\"}")));
 
-    String payload = "{\"data\":\"success\"}";
-
-    DeliveryDTO delivery =
-        webhookService.deliver(payload, WebhookEventType.CUSTOM, webhook.getId());
+    DeliveryDTO delivery = webhookService.ping(webhook.getId());
 
     assertEquals(200, delivery.getHttpStatusCode());
     trustedHttpsServer.verify(
         postRequestedFor(urlEqualTo("/test-endpoint"))
             .withHeader("Content-Type", equalTo("application/json"))
-            .withRequestBody(matchingJsonPath("$.type", equalTo(WebhookEventType.CUSTOM.value())))
-            .withRequestBody(matchingJsonPath("$.timestamp"))
-            .withRequestBody(matchingJsonPath("$.data.data", equalTo("success"))));
+            .withRequestBody(matchingJsonPath("$.type", equalTo(WebhookEventType.PING.value())))
+            .withRequestBody(matchingJsonPath("$.timestamp")));
   }
 
   @Test
@@ -98,10 +94,7 @@ public class WebhookDeliverySslIntegrationTest {
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                     .withBody("{\"status\":\"received\"}")));
 
-    String payload = "{\"data\":\"success\"}";
-
-    DeliveryDTO delivery =
-        webhookService.deliver(payload, WebhookEventType.CUSTOM, webhook.getId());
+    DeliveryDTO delivery = webhookService.ping(webhook.getId());
 
     assertNull(delivery.getHttpStatusCode());
     assertEquals("SSL certificate validation failed", delivery.getErrorMessage());
@@ -121,18 +114,14 @@ public class WebhookDeliverySslIntegrationTest {
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                     .withBody("{\"status\":\"received\"}")));
 
-    String payload = "{\"data\":\"success\"}";
-
-    DeliveryDTO delivery =
-        webhookService.deliver(payload, WebhookEventType.CUSTOM, webhook.getId());
+    DeliveryDTO delivery = webhookService.ping(webhook.getId());
 
     assertEquals(200, delivery.getHttpStatusCode());
     trustedHttpsServer.verify(
         postRequestedFor(urlEqualTo("/test-endpoint"))
             .withHeader("Content-Type", equalTo("application/json"))
-            .withRequestBody(matchingJsonPath("$.type", equalTo(WebhookEventType.CUSTOM.value())))
-            .withRequestBody(matchingJsonPath("$.timestamp"))
-            .withRequestBody(matchingJsonPath("$.data.data", equalTo("success"))));
+            .withRequestBody(matchingJsonPath("$.type", equalTo(WebhookEventType.PING.value())))
+            .withRequestBody(matchingJsonPath("$.timestamp")));
   }
 
   @Test
@@ -149,17 +138,13 @@ public class WebhookDeliverySslIntegrationTest {
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                     .withBody("{\"status\":\"received\"}")));
 
-    String payload = "{\"data\":\"success\"}";
-
-    DeliveryDTO delivery =
-        webhookService.deliver(payload, WebhookEventType.CUSTOM, webhook.getId());
+    DeliveryDTO delivery = webhookService.ping(webhook.getId());
 
     assertEquals(200, delivery.getHttpStatusCode());
     untrustedHttpsServer.verify(
         postRequestedFor(urlEqualTo("/test-endpoint"))
             .withHeader("Content-Type", equalTo("application/json"))
-            .withRequestBody(matchingJsonPath("$.type", equalTo(WebhookEventType.CUSTOM.value())))
-            .withRequestBody(matchingJsonPath("$.timestamp"))
-            .withRequestBody(matchingJsonPath("$.data.data", equalTo("success"))));
+            .withRequestBody(matchingJsonPath("$.type", equalTo(WebhookEventType.PING.value())))
+            .withRequestBody(matchingJsonPath("$.timestamp")));
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookDeliveryTransactionBoundaryIntegrationTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookDeliveryTransactionBoundaryIntegrationTest.java
@@ -18,7 +18,6 @@ import eu.bbmri_eric.negotiator.webhook.DeliveryDTO;
 import eu.bbmri_eric.negotiator.webhook.Webhook;
 import eu.bbmri_eric.negotiator.webhook.WebhookRepository;
 import eu.bbmri_eric.negotiator.webhook.WebhookService;
-import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -61,15 +60,9 @@ class WebhookDeliveryTransactionBoundaryIntegrationTest {
 
     try (ExecutorService executor = Executors.newFixedThreadPool(3)) {
       Future<DeliveryDTO> firstDeliveryFuture =
-          executor.submit(
-              () ->
-                  webhookService.deliver(
-                      "{\"delivery\":1}", WebhookEventType.CUSTOM, firstWebhook.getId()));
+          executor.submit(() -> webhookService.ping(firstWebhook.getId()));
       Future<DeliveryDTO> secondDeliveryFuture =
-          executor.submit(
-              () ->
-                  webhookService.deliver(
-                      "{\"delivery\":2}", WebhookEventType.CUSTOM, secondWebhook.getId()));
+          executor.submit(() -> webhookService.ping(secondWebhook.getId()));
 
       await("both delivery attempts")
           .atMost(Duration.ofSeconds(2))

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookDeliveryTransportFaultIntegrationTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookDeliveryTransportFaultIntegrationTest.java
@@ -15,7 +15,6 @@ import eu.bbmri_eric.negotiator.webhook.DeliveryDTO;
 import eu.bbmri_eric.negotiator.webhook.Webhook;
 import eu.bbmri_eric.negotiator.webhook.WebhookRepository;
 import eu.bbmri_eric.negotiator.webhook.WebhookService;
-import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,10 +51,7 @@ class WebhookDeliveryTransportFaultIntegrationTest {
     wireMockServer.stubFor(
         post(urlEqualTo("/slow-endpoint")).willReturn(ok().withFixedDelay(3000).withBody("ok")));
 
-    String payload = "{\"data\":\"success\"}";
-
-    DeliveryDTO delivery =
-        webhookService.deliver(payload, WebhookEventType.CUSTOM, webhook.getId());
+    DeliveryDTO delivery = webhookService.ping(webhook.getId());
 
     assertNull(delivery.getHttpStatusCode());
     assertEquals("Request timeout", delivery.getErrorMessage());
@@ -71,10 +67,7 @@ class WebhookDeliveryTransportFaultIntegrationTest {
     wireMockServer.stubFor(
         post(urlEqualTo("/fault-endpoint")).willReturn(ok().withFault(fault).withBody("fault")));
 
-    String payload = "{\"data\":\"fault\"}";
-
-    DeliveryDTO delivery =
-        webhookService.deliver(payload, WebhookEventType.CUSTOM, webhook.getId());
+    DeliveryDTO delivery = webhookService.ping(webhook.getId());
 
     assertTrue(delivery.getHttpStatusCode() == null || delivery.getHttpStatusCode() >= 500);
     assertTrue(StringUtils.isNotBlank(delivery.getErrorMessage()));
@@ -88,10 +81,7 @@ class WebhookDeliveryTransportFaultIntegrationTest {
     Webhook webhook =
         webhookRepository.save(new Webhook("http://localhost/{missingVar}", true, true));
 
-    String payload = "{\"data\":\"runtime\"}";
-
-    DeliveryDTO delivery =
-        webhookService.deliver(payload, WebhookEventType.CUSTOM, webhook.getId());
+    DeliveryDTO delivery = webhookService.ping(webhook.getId());
 
     assertNull(delivery.getHttpStatusCode());
     assertTrue(StringUtils.isNotBlank(delivery.getErrorMessage()));

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookRedeliveryIntegrationTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookRedeliveryIntegrationTest.java
@@ -58,10 +58,7 @@ public class WebhookRedeliveryIntegrationTest {
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                     .withBody("{\"status\":\"received\"}")));
 
-    String payload = "{\"data\":\"redelivery\"}";
-
-    DeliveryDTO firstDelivery =
-        webhookService.deliver(payload, WebhookEventType.CUSTOM, webhook.getId());
+    DeliveryDTO firstDelivery = webhookService.ping(webhook.getId());
 
     long firstAttemptTimestamp =
         getAllServeEvents().stream()
@@ -91,9 +88,8 @@ public class WebhookRedeliveryIntegrationTest {
         3,
         postRequestedFor(urlEqualTo("/redeliver-endpoint"))
             .withHeader("Content-Type", equalTo("application/json"))
-            .withRequestBody(matchingJsonPath("$.type", equalTo(WebhookEventType.CUSTOM.value())))
-            .withRequestBody(matchingJsonPath("$.timestamp"))
-            .withRequestBody(matchingJsonPath("$.data.data", equalTo("redelivery"))));
+            .withRequestBody(matchingJsonPath("$.type", equalTo(WebhookEventType.PING.value())))
+            .withRequestBody(matchingJsonPath("$.timestamp")));
 
     var serveEvents =
         getAllServeEvents().stream()

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookSignatureReferenceVerificationIntegrationTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookSignatureReferenceVerificationIntegrationTest.java
@@ -21,7 +21,6 @@ import eu.bbmri_eric.negotiator.webhook.WebhookHeaders;
 import eu.bbmri_eric.negotiator.webhook.WebhookRepository;
 import eu.bbmri_eric.negotiator.webhook.WebhookSecretService;
 import eu.bbmri_eric.negotiator.webhook.WebhookService;
-import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -65,8 +64,7 @@ class WebhookSignatureReferenceVerificationIntegrationTest {
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                     .withBody("{\"status\":\"received\"}")));
 
-    DeliveryDTO delivery =
-        webhookService.deliver("{\"data\":\"signed\"}", WebhookEventType.CUSTOM, webhook.getId());
+    DeliveryDTO delivery = webhookService.ping(webhook.getId());
 
     assertEquals(200, delivery.getHttpStatusCode());
     verify(1, postRequestedFor(urlEqualTo("/signed-endpoint")));

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/unit/model/WebhookEntityTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/unit/model/WebhookEntityTest.java
@@ -25,7 +25,7 @@ public class WebhookEntityTest {
   @Test
   void testAddSingleDeliveryWith200() {
     Delivery delivery =
-        new Delivery("{\"message\":\"Test delivery 1\"}", 200, WebhookEventType.CUSTOM);
+        new Delivery("{\"message\":\"Test delivery 1\"}", 200, WebhookEventType.PING);
     webhook.addDelivery(delivery);
     assertEquals(1, webhook.getDeliveries().size());
     assertEquals(webhook.getId(), delivery.getWebhookId());
@@ -36,7 +36,7 @@ public class WebhookEntityTest {
   void testAddMultipleDeliveriesWithinLimit() {
     for (int i = 1; i <= 5; i++) {
       Delivery delivery =
-          new Delivery("{\"message\":\"Delivery " + i + "\"}", 200, WebhookEventType.CUSTOM);
+          new Delivery("{\"message\":\"Delivery " + i + "\"}", 200, WebhookEventType.PING);
       webhook.addDelivery(delivery);
     }
     assertEquals(5, webhook.getDeliveries().size());
@@ -51,7 +51,7 @@ public class WebhookEntityTest {
   void testAddMoreThan100Deliveries() {
     for (int i = 1; i <= 105; i++) {
       Delivery delivery =
-          new Delivery("{\"message\":\"Delivery " + i + "\"}", 200, WebhookEventType.CUSTOM);
+          new Delivery("{\"message\":\"Delivery " + i + "\"}", 200, WebhookEventType.PING);
       webhook.addDelivery(delivery);
     }
     assertEquals(100, webhook.getDeliveries().size());
@@ -64,7 +64,7 @@ public class WebhookEntityTest {
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new Delivery("{\"message\":\"Error delivery\"}", 500, WebhookEventType.CUSTOM));
+            () -> new Delivery("{\"message\":\"Error delivery\"}", 500, WebhookEventType.PING));
     assertEquals("Non-200 HTTP status code requires an error message.", exception.getMessage());
   }
 
@@ -72,7 +72,7 @@ public class WebhookEntityTest {
   void testAddDeliveryNon200WithErrorMessage() {
     Delivery delivery =
         new Delivery(
-            "{\"message\":\"Error delivery\"}", 500, "Server error", WebhookEventType.CUSTOM);
+            "{\"message\":\"Error delivery\"}", 500, "Server error", WebhookEventType.PING);
     webhook.addDelivery(delivery);
     assertEquals(1, webhook.getDeliveries().size());
     assertEquals("Server error", delivery.getErrorMessage());
@@ -81,11 +81,11 @@ public class WebhookEntityTest {
 
   @Test
   void testDeliveriesOrderedByAtDescending() {
-    Delivery d1 = new Delivery("{\"message\":\"Oldest\"}", 200, WebhookEventType.CUSTOM);
+    Delivery d1 = new Delivery("{\"message\":\"Oldest\"}", 200, WebhookEventType.PING);
     d1.setAt(LocalDateTime.now().minusMinutes(10));
-    Delivery d2 = new Delivery("{\"message\":\"Middle\"}", 200, WebhookEventType.CUSTOM);
+    Delivery d2 = new Delivery("{\"message\":\"Middle\"}", 200, WebhookEventType.PING);
     d2.setAt(LocalDateTime.now().minusMinutes(5));
-    Delivery d3 = new Delivery("{\"message\":\"Newest\"}", 200, WebhookEventType.CUSTOM);
+    Delivery d3 = new Delivery("{\"message\":\"Newest\"}", 200, WebhookEventType.PING);
     d3.setAt(LocalDateTime.now());
     webhook.addDelivery(d1);
     webhook.addDelivery(d2);

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryDispatcherTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryDispatcherTest.java
@@ -3,7 +3,6 @@ package eu.bbmri_eric.negotiator.webhook;
 import static org.mockito.Mockito.verify;
 
 import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
-import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,12 +23,10 @@ class WebhookDeliveryDispatcherTest {
 
   @Test
   void scheduleDelivery_delegatesToWebhookService() {
-    Instant occurredAt = Instant.parse("2026-01-01T00:00:00Z");
-
     dispatcher.scheduleDelivery(
-        1L, "{\"key\":\"value\"}", WebhookEventType.NEGOTIATION_INFO_UPDATED, occurredAt);
+        1L, "{\"key\":\"value\"}", WebhookEventType.NEGOTIATION_INFO_UPDATED);
 
     verify(webhookService)
-        .deliver("{\"key\":\"value\"}", WebhookEventType.NEGOTIATION_INFO_UPDATED, 1L, occurredAt);
+        .deliver("{\"key\":\"value\"}", WebhookEventType.NEGOTIATION_INFO_UPDATED, 1L);
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryPersisterTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookDeliveryPersisterTest.java
@@ -37,7 +37,7 @@ class WebhookDeliveryPersisterTest {
     Long webhookId = 1L;
     Webhook webhook = new Webhook("https://example.com/webhook", true, true);
     webhook.setId(webhookId);
-    Delivery delivery = new Delivery("{\"test\":\"ok\"}", 200, WebhookEventType.CUSTOM);
+    Delivery delivery = new Delivery("{\"test\":\"ok\"}", 200, WebhookEventType.PING);
     DeliveryDTO expected = new DeliveryDTO();
 
     when(webhookRepository.findById(webhookId)).thenReturn(Optional.of(webhook));
@@ -57,7 +57,7 @@ class WebhookDeliveryPersisterTest {
   void persist_whenWebhookDoesNotExist_throwsEntityNotFoundException() {
     Long webhookId = 99L;
     Delivery delivery =
-        new Delivery("{\"test\":\"not-found\"}", 500, "error", WebhookEventType.CUSTOM);
+        new Delivery("{\"test\":\"not-found\"}", 500, "error", WebhookEventType.PING);
 
     when(webhookRepository.findById(webhookId)).thenReturn(Optional.empty());
 

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListenerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookEventListenerTest.java
@@ -48,7 +48,7 @@ class WebhookEventListenerTest {
     webhookEventListener.onWebhookEvent(unsupportedEvent);
 
     verify(objectMapper, never()).writeValueAsString(any());
-    verify(webhookDeliveryDispatcher, never()).scheduleDelivery(any(), any(), any(), any());
+    verify(webhookDeliveryDispatcher, never()).scheduleDelivery(any(), any(), any());
   }
 
   @Test
@@ -66,7 +66,7 @@ class WebhookEventListenerTest {
 
     webhookEventListener.onWebhookEvent(event);
 
-    verify(webhookDeliveryDispatcher, never()).scheduleDelivery(any(), any(), any(), any());
+    verify(webhookDeliveryDispatcher, never()).scheduleDelivery(any(), any(), any());
   }
 
   @Test
@@ -90,14 +90,12 @@ class WebhookEventListenerTest {
         .scheduleDelivery(
             1L,
             "{\"type\":\"negotiation.info.updated\",\"timestamp\":\"2026-01-01T00:00:00Z\",\"data\":{\"negotiationId\":\"negotiation-1\"}}",
-            WebhookEventType.NEGOTIATION_INFO_UPDATED,
-            Instant.parse("2026-01-01T00:00:00Z"));
+            WebhookEventType.NEGOTIATION_INFO_UPDATED);
     verify(webhookDeliveryDispatcher)
         .scheduleDelivery(
             2L,
             "{\"type\":\"negotiation.info.updated\",\"timestamp\":\"2026-01-01T00:00:00Z\",\"data\":{\"negotiationId\":\"negotiation-1\"}}",
-            WebhookEventType.NEGOTIATION_INFO_UPDATED,
-            Instant.parse("2026-01-01T00:00:00Z"));
+            WebhookEventType.NEGOTIATION_INFO_UPDATED);
   }
 
   @Test
@@ -116,6 +114,6 @@ class WebhookEventListenerTest {
 
     webhookEventListener.onWebhookEvent(event);
 
-    verify(webhookDeliveryDispatcher, never()).scheduleDelivery(any(), any(), any(), any());
+    verify(webhookDeliveryDispatcher, never()).scheduleDelivery(any(), any(), any());
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImplTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImplTest.java
@@ -1,0 +1,87 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
+import eu.bbmri_eric.negotiator.webhook.event.WebhookPayloadEnvelope;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class WebhookServiceImplTest {
+
+  @Mock private WebhookRepository webhookRepository;
+  @Mock private DeliveryRepository deliveryRepository;
+  @Mock private ModelMapper modelMapper;
+  @Mock private WebhookDeliveryPersister webhookDeliveryPersister;
+  @Mock private WebhookSecretService webhookSecretService;
+  @Mock private WebhookSigningService webhookSigningService;
+  @Mock private RestTemplate secureRestTemplate;
+  @Mock private RestTemplate insecureRestTemplate;
+
+  private WebhookServiceImpl service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new WebhookServiceImpl(
+            webhookRepository,
+            deliveryRepository,
+            modelMapper,
+            new ObjectMapper(),
+            webhookDeliveryPersister,
+            webhookSecretService,
+            webhookSigningService,
+            secureRestTemplate,
+            insecureRestTemplate);
+  }
+
+  @Test
+  void ping_whenPayloadEnvelopeIsNotSerializable_throwsIllegalStateException() {
+    Long webhookId = 1L;
+    var payloadEnvelope =
+        new WebhookPayloadEnvelope<>(
+            WebhookEventType.PING, Instant.now(), new NonSerializablePing());
+
+    try (MockedStatic<?> mockedPing = mockStatic(WebhookPayloadEnvelope.class)) {
+      mockedPing
+          .when(() -> WebhookPayloadEnvelope.ping(eq(webhookId), any(Instant.class)))
+          .thenReturn(payloadEnvelope);
+
+      IllegalStateException ex =
+          assertThrows(IllegalStateException.class, () -> service.ping(webhookId));
+
+      assertEquals("Could not serialize webhook payload", ex.getMessage());
+      assertInstanceOf(JsonProcessingException.class, ex.getCause());
+    }
+
+    verifyNoInteractions(
+        webhookRepository,
+        deliveryRepository,
+        webhookDeliveryPersister,
+        secureRestTemplate,
+        insecureRestTemplate);
+  }
+
+  @SuppressWarnings("unused")
+  private static final class NonSerializablePing {
+    public String getWebhookId() {
+      throw new UnsupportedOperationException("Cannot serialize ping payload");
+    }
+  }
+}

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImplTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/WebhookServiceImplTest.java
@@ -52,6 +52,22 @@ class WebhookServiceImplTest {
   }
 
   @Test
+  void deliver_whenPayloadIsInvalidJson_throwsIllegalArgumentException() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> service.deliver("not-valid-json", WebhookEventType.PING, 1L));
+
+    assertEquals("Content is not a valid JSON", ex.getMessage());
+    verifyNoInteractions(
+        webhookRepository,
+        deliveryRepository,
+        webhookDeliveryPersister,
+        secureRestTemplate,
+        insecureRestTemplate);
+  }
+
+  @Test
   void ping_whenPayloadEnvelopeIsNotSerializable_throwsIllegalStateException() {
     Long webhookId = 1L;
     var payloadEnvelope =

--- a/frontend/src/store/admin.js
+++ b/frontend/src/store/admin.js
@@ -106,18 +106,14 @@ export const useAdminStore = defineStore('admin', () => {
 
   function testWebhook(webhookId) {
     return axios
-      .post(
-        `${apiPaths.BASE_API_PATH}/webhooks/${webhookId}/deliveries`,
-        { test: 'yes' },
-        {
-          headers: getBearerHeaders(),
-        },
-      )
+      .post(`${apiPaths.BASE_API_PATH}/webhooks/${webhookId}/ping`, null, {
+        headers: getBearerHeaders(),
+      })
       .then((response) => {
         return response.data
       })
       .catch((error) => {
-        notifications.setNotification('Failed to send test delivery', 'danger')
+        notifications.setNotification('Failed to send test ping', 'danger')
         throw error
       })
   }


### PR DESCRIPTION
### Description:

This pull request introduces a new standardized "ping" delivery endpoint for webhooks, removes the legacy custom delivery endpoint, and refactors related service and event code to support the new ping mechanism. It also updates the integration tests to validate the new ping behavior and cleans up unused code paths and event types.

**Webhook Ping Delivery Feature and Refactor**

*API changes:*
- Adds a new `/v3/webhooks/{id}/ping` endpoint to send a standardized ping payload to the specified webhook, replacing the previous custom delivery endpoint. (`WebhookController.java`, [backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookController.javaL79-R81](diffhunk://#diff-6eb083ddecbd06e98d39c78a8065de18f15a297a71cefbb83c9d42b530ae9c2cL79-R81))
- Removes the now-unused custom delivery endpoint and associated event type. (`WebhookController.java`, [[1]](diffhunk://#diff-6eb083ddecbd06e98d39c78a8065de18f15a297a71cefbb83c9d42b530ae9c2cL79-R81); `WebhookEventType.java`, [[2]](diffhunk://#diff-20513eceebd05b1683e3b061a921f990ffc0e5729f987dccba47c0e9896a9e79L10-R16)

*Service and event refactoring:*
- Implements the `ping` method in `WebhookService` and `WebhookServiceImpl`, which constructs and sends a standardized ping payload envelope. (`WebhookService.java`, [[1]](diffhunk://#diff-cad39a2c9803f1593f123d4cc2b5828f898eee5f31a69fdb24b15c235e4a2695R56-R63); `WebhookServiceImpl.java`, [[2]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L116-R130)
- Removes the legacy `deliver` method with explicit timestamp and the `CUSTOM` event type, simplifying the delivery interface. (`WebhookService.java`, [[1]](diffhunk://#diff-cad39a2c9803f1593f123d4cc2b5828f898eee5f31a69fdb24b15c235e4a2695L67-L78); `WebhookServiceImpl.java`, [[2]](diffhunk://#diff-ec12bff142984387833b50d9afc48caed13f99c4ff6cafeacf92d890938c4147L145-L159); `WebhookEventType.java`, [[3]](diffhunk://#diff-20513eceebd05b1683e3b061a921f990ffc0e5729f987dccba47c0e9896a9e79L10-R16)
- Adds `PingWebhookEvent` and updates `WebhookPayloadEnvelope` to support the new ping payload structure. (`PingWebhookEvent.java`, [[1]](diffhunk://#diff-1e0801954ec6985dd7e58049410c1b77df92dfb5ed1186424908b3346c15c2b1R1-R8); `WebhookPayloadEnvelope.java`, [[2]](diffhunk://#diff-334699ff9474eaa598e8aa7b7a3179e13381ec3e861c4f31975b9d8aaf8fed9aL14-R17)

*Dispatcher and listener adjustments:*
- Updates `WebhookDeliveryDispatcher` and `WebhookEventListener` to remove support for explicit event timestamps and custom events, aligning with the new simplified delivery contract. (`WebhookDeliveryDispatcher.java`, [[1]](diffhunk://#diff-09266c6b538690b1d5c45025a393c9ff9f8669577cedb5e001f72cc4ae02335aL26-R28); `WebhookEventListener.java`, [[2]](diffhunk://#diff-abdc6b72c47075e89db6a95ac74cfe9ee785205fe8daced200874751555043d6L58-R58)

*Test updates:*
- Refactors integration tests to use and validate the new `/ping` endpoint, including tests for successful delivery, error handling, and payload verification. (`WebhookControllerTest.java`, [[1]](diffhunk://#diff-b824380a7847cf37787b2b6b5736be9188f5182ec9d5f64b08bbc18ed4856b70L201-R210) [[2]](diffhunk://#diff-b824380a7847cf37787b2b6b5736be9188f5182ec9d5f64b08bbc18ed4856b70L222-R247) [[3]](diffhunk://#diff-b824380a7847cf37787b2b6b5736be9188f5182ec9d5f64b08bbc18ed4856b70L270-R267) [[4]](diffhunk://#diff-b824380a7847cf37787b2b6b5736be9188f5182ec9d5f64b08bbc18ed4856b70L292-R276) [[5]](diffhunk://#diff-b824380a7847cf37787b2b6b5736be9188f5182ec9d5f64b08bbc18ed4856b70L309-R307) [[6]](diffhunk://#diff-b824380a7847cf37787b2b6b5736be9188f5182ec9d5f64b08bbc18ed4856b70L351-R335)
### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
