### PR TITLE
fix: postgres health check

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -38,7 +38,7 @@ services:
       - POSTGRES_PASSWORD=negotiator
       - POSTGRES_DB=negotiator
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready", "-d", "negotiator" ]
+      test: [ "CMD", "pg_isready", "-d", "negotiator", "-U", "negotiator" ]
       interval: 5s
       timeout: 60s
       retries: 5


### PR DESCRIPTION
### Description:

Setting the user for the postgres healthcheck explicitly because the `root` may be used. Also using `CMD` over `CMD-SHELL`, as we use `CMD` syntax.

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
