### PR TITLE
feat: webhooks documentation

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/configuration/SwaggerConfig.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/configuration/SwaggerConfig.java
@@ -1,13 +1,16 @@
 package eu.bbmri_eric.negotiator.common.configuration;
 
+import eu.bbmri_eric.negotiator.webhook.WebhookOpenApiDocumentationFactory;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.security.Scopes;
 import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,11 +27,29 @@ public class SwaggerConfig {
   private List<String> scopes;
 
   @Bean
-  public OpenAPI customOpenAPI() {
+  OpenAPI customOpenAPI(WebhookOpenApiDocumentationFactory webhookOpenApiDocumentationFactory) {
     Scopes oauthScopes = new Scopes();
     for (String scope : scopes) {
       oauthScopes.addString(scope, "no description");
     }
+
+    Components components =
+        new Components()
+            .addSecuritySchemes(
+                "security_auth",
+                new io.swagger.v3.oas.models.security.SecurityScheme()
+                    .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.OAUTH2)
+                    .flows(
+                        new io.swagger.v3.oas.models.security.OAuthFlows()
+                            .authorizationCode(
+                                new io.swagger.v3.oas.models.security.OAuthFlow()
+                                    .authorizationUrl(authorizationUrl)
+                                    .tokenUrl(tokenUrl)
+                                    .scopes(oauthScopes))));
+
+    Map<String, PathItem> webhookPaths =
+        webhookOpenApiDocumentationFactory.buildWebhookPaths(components);
+
     return new OpenAPI()
         .externalDocs(
             new ExternalDocumentation()
@@ -52,18 +73,7 @@ public class SwaggerConfig {
                         .name("BBMRI-ERIC CS-IT")
                         .url("https://www.bbmri-eric.eu/bbmri-eric/common-service-it/"))
                 .version("3.0.0"))
-        .components(
-            new Components()
-                .addSecuritySchemes(
-                    "security_auth",
-                    new io.swagger.v3.oas.models.security.SecurityScheme()
-                        .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.OAUTH2)
-                        .flows(
-                            new io.swagger.v3.oas.models.security.OAuthFlows()
-                                .authorizationCode(
-                                    new io.swagger.v3.oas.models.security.OAuthFlow()
-                                        .authorizationUrl(authorizationUrl)
-                                        .tokenUrl(tokenUrl)
-                                        .scopes(oauthScopes)))));
+        .webhooks(webhookPaths)
+        .components(components);
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookHeaderDoc.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookHeaderDoc.java
@@ -1,0 +1,22 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Metadata used for generated OpenAPI webhook header documentation. */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface WebhookHeaderDoc {
+  /** Human-readable webhook header description shown in OpenAPI docs. */
+  String description();
+
+  /** Whether the webhook header is required on delivery. */
+  boolean required();
+
+  /** Optional OpenAPI example value for the header. */
+  String example() default "";
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookHeaders.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookHeaders.java
@@ -5,7 +5,21 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WebhookHeaders {
+  @WebhookHeaderDoc(
+      description = "Optional webhook signature in the format v1,<base64-digest>",
+      required = false,
+      example = "v1,1+jttfc8wkgmg2OT+W+HYN8WwS7i4o+UWhIQuvPzHMg=")
   public static final String SIGNATURE = "Webhook-Signature";
+
+  @WebhookHeaderDoc(
+      description = "Unix epoch timestamp in seconds",
+      required = true,
+      example = "1713943330")
   public static final String TIMESTAMP = "Webhook-Timestamp";
+
+  @WebhookHeaderDoc(
+      description = "Unique webhook message identifier used for signature verification",
+      required = true,
+      example = "123e4567-e89b-12d3-a456-426614174000")
   public static final String WEBHOOK_ID = "Webhook-Id";
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookOpenApiDocumentationFactory.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/WebhookOpenApiDocumentationFactory.java
@@ -1,0 +1,206 @@
+package eu.bbmri_eric.negotiator.webhook;
+
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventDoc;
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventMapper;
+import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.converter.ResolvedSchema;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.springframework.stereotype.Component;
+
+/** Builds generated OpenAPI webhook documentation from mapped webhook event definitions. */
+@Component
+public class WebhookOpenApiDocumentationFactory {
+  private static final String APPLICATION_JSON = "application/json";
+
+  private final WebhookEventMapper webhookEventMapper;
+  private final List<WebhookHeaderDocumentation> webhookHeaderDocumentation;
+
+  public WebhookOpenApiDocumentationFactory(WebhookEventMapper webhookEventMapper) {
+    this.webhookEventMapper = webhookEventMapper;
+    this.webhookHeaderDocumentation = discoverWebhookHeaderDocumentation();
+  }
+
+  /**
+   * Builds webhook path documentation and registers the related schemas in components.
+   *
+   * @param components mutable OpenAPI components container
+   * @return immutable map of OpenAPI webhook path items keyed by event type value
+   */
+  public Map<String, PathItem> buildWebhookPaths(Components components) {
+    Map<String, PathItem> webhookPaths = new TreeMap<>();
+    for (Map.Entry<WebhookEventType, Class<?>> definition :
+        webhookEventMapper.documentedPayloadTypes().entrySet()) {
+      WebhookEventType eventType = definition.getKey();
+      Class<?> dataType = definition.getValue();
+      String dataSchemaName = registerDataSchema(components, dataType);
+      String envelopeSchemaName =
+          registerEnvelopeSchema(components, eventType, dataType, dataSchemaName);
+      webhookPaths.put(
+          eventType.value(),
+          new PathItem().post(buildWebhookOperation(eventType, dataType, envelopeSchemaName)));
+    }
+    return Map.copyOf(webhookPaths);
+  }
+
+  private String registerDataSchema(Components components, Class<?> dataType) {
+    ResolvedSchema resolvedSchema =
+        ModelConverters.getInstance().resolveAsResolvedSchema(new AnnotatedType(dataType));
+    if (resolvedSchema.referencedSchemas != null) {
+      resolvedSchema.referencedSchemas.forEach(components::addSchemas);
+    }
+
+    String dataSchemaName = dataType.getSimpleName();
+    Schema<?> dataSchema = resolvedSchema.schema;
+    if (dataSchema == null && resolvedSchema.referencedSchemas != null) {
+      dataSchema = resolvedSchema.referencedSchemas.get(dataSchemaName);
+    }
+    if (dataSchema == null) {
+      dataSchema = new ObjectSchema();
+    }
+
+    dataSchema.setName(dataSchemaName);
+    components.addSchemas(dataSchemaName, dataSchema);
+    return dataSchemaName;
+  }
+
+  private String registerEnvelopeSchema(
+      Components components, WebhookEventType eventType, Class<?> dataType, String dataSchemaName) {
+    String envelopeSchemaName = dataType.getSimpleName() + "Envelope";
+    ObjectSchema envelopeSchema = new ObjectSchema();
+    envelopeSchema.setDescription(
+        "Outbound webhook envelope for event type '" + eventType.value() + "'.");
+
+    StringSchema eventTypeSchema = new StringSchema();
+    eventTypeSchema.description("Semantic webhook event type");
+    eventTypeSchema.example(eventType.value());
+    eventTypeSchema.setEnum(List.of(eventType.value()));
+    envelopeSchema.addProperty("type", eventTypeSchema);
+
+    envelopeSchema.addProperty(
+        "timestamp",
+        new StringSchema()
+            .description("UTC timestamp describing when the source event happened")
+            .format("date-time")
+            .example("2026-04-24T07:12:30Z"));
+    envelopeSchema.addProperty(
+        "data", new Schema<>().$ref("#/components/schemas/" + dataSchemaName));
+    envelopeSchema.setRequired(List.of("type", "timestamp", "data"));
+    components.addSchemas(envelopeSchemaName, envelopeSchema);
+    return envelopeSchemaName;
+  }
+
+  private Operation buildWebhookOperation(
+      WebhookEventType eventType, Class<?> dataType, String envelopeSchemaName) {
+    Operation operation =
+        new Operation()
+            .summary(resolveWebhookSummary(eventType, dataType))
+            .description(resolveWebhookDescription(eventType, dataType))
+            .requestBody(
+                new RequestBody()
+                    .required(true)
+                    .content(
+                        new Content()
+                            .addMediaType(
+                                APPLICATION_JSON,
+                                new MediaType()
+                                    .schema(
+                                        new Schema<>()
+                                            .$ref("#/components/schemas/" + envelopeSchemaName)))))
+            .responses(
+                new ApiResponses()
+                    .addApiResponse("200", new ApiResponse().description("Webhook accepted"))
+                    .addApiResponse("400", new ApiResponse().description("Invalid payload")));
+
+    webhookHeaderDocumentation.forEach(
+        headerDocumentation ->
+            operation.addParametersItem(webhookHeaderParameter(headerDocumentation)));
+    return operation;
+  }
+
+  private Parameter webhookHeaderParameter(WebhookHeaderDocumentation headerDocumentation) {
+    Parameter parameter =
+        new Parameter()
+            .in("header")
+            .name(headerDocumentation.name())
+            .description(headerDocumentation.description())
+            .required(headerDocumentation.required())
+            .schema(new StringSchema());
+
+    if (!headerDocumentation.example().isBlank()) {
+      parameter.example(headerDocumentation.example());
+    }
+    return parameter;
+  }
+
+  private static WebhookHeaderDocumentation toWebhookHeaderDocumentation(Field headerField) {
+    String fieldName = headerField.getName();
+    WebhookHeaderDoc headerDoc = headerField.getAnnotation(WebhookHeaderDoc.class);
+    if (headerDoc == null) {
+      throw new IllegalStateException(
+          "Missing @WebhookHeaderDoc on webhook header constant: " + fieldName);
+    }
+
+    String headerName;
+    try {
+      headerName = (String) headerField.get(null);
+    } catch (IllegalAccessException exception) {
+      throw new IllegalStateException(
+          "Unable to access webhook header constant: " + fieldName, exception);
+    }
+
+    return new WebhookHeaderDocumentation(
+        headerName, headerDoc.description(), headerDoc.required(), headerDoc.example());
+  }
+
+  private static List<WebhookHeaderDocumentation> discoverWebhookHeaderDocumentation() {
+    return Arrays.stream(WebhookHeaders.class.getDeclaredFields())
+        .filter(WebhookOpenApiDocumentationFactory::isWebhookHeaderField)
+        .map(WebhookOpenApiDocumentationFactory::toWebhookHeaderDocumentation)
+        .toList();
+  }
+
+  private static boolean isWebhookHeaderField(Field field) {
+    int modifiers = field.getModifiers();
+    return Modifier.isStatic(modifiers)
+        && Modifier.isFinal(modifiers)
+        && String.class.equals(field.getType());
+  }
+
+  private record WebhookHeaderDocumentation(
+      String name, String description, boolean required, String example) {}
+
+  private String resolveWebhookSummary(WebhookEventType eventType, Class<?> dataType) {
+    WebhookEventDoc eventDoc = dataType.getAnnotation(WebhookEventDoc.class);
+    if (eventDoc == null || eventDoc.summary().isBlank()) {
+      return "Webhook event: " + eventType.value();
+    }
+    return eventDoc.summary();
+  }
+
+  private String resolveWebhookDescription(WebhookEventType eventType, Class<?> dataType) {
+    WebhookEventDoc eventDoc = dataType.getAnnotation(WebhookEventDoc.class);
+    if (eventDoc == null || eventDoc.description().isBlank()) {
+      return "Outbound webhook event for '" + eventType.value() + "'.";
+    }
+    return eventDoc.description();
+  }
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationAddedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationAddedWebhookEvent.java
@@ -1,8 +1,16 @@
 package eu.bbmri_eric.negotiator.webhook.event;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Webhook data payload for a newly created negotiation.
  *
  * @param negotiationId identifier of the created negotiation
  */
-record NegotiationAddedWebhookEvent(String negotiationId) {}
+@WebhookEventDoc(
+    summary = "Negotiation created",
+    description = "Sent when a new negotiation is created in the Negotiator.")
+@Schema(description = "Webhook data payload for a newly created negotiation.")
+record NegotiationAddedWebhookEvent(
+    @Schema(description = "Identifier of the created negotiation", example = "negotiation-3")
+        String negotiationId) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationInfoUpdatedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationInfoUpdatedWebhookEvent.java
@@ -1,8 +1,16 @@
 package eu.bbmri_eric.negotiator.webhook.event;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Webhook data payload for an updated information submission in a negotiation.
  *
  * @param negotiationId identifier of the affected negotiation
  */
-record NegotiationInfoUpdatedWebhookEvent(String negotiationId) {}
+@WebhookEventDoc(
+    summary = "Negotiation information updated",
+    description = "Sent when additional information for a negotiation was submitted or updated.")
+@Schema(description = "Webhook data payload for updated negotiation information.")
+record NegotiationInfoUpdatedWebhookEvent(
+    @Schema(description = "Identifier of the affected negotiation", example = "negotiation-1")
+        String negotiationId) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationPostAddedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationPostAddedWebhookEvent.java
@@ -1,5 +1,7 @@
 package eu.bbmri_eric.negotiator.webhook.event;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Webhook data payload for a newly created negotiation post.
  *
@@ -8,5 +10,20 @@ package eu.bbmri_eric.negotiator.webhook.event;
  * @param userId identifier of the user that created the post
  * @param organizationId optional identifier of the organization context
  */
+@WebhookEventDoc(
+    summary = "Negotiation post added",
+    description = "Sent when a new post is added to a negotiation discussion.")
+@Schema(description = "Webhook data payload for a newly created negotiation post.")
 record NegotiationPostAddedWebhookEvent(
-    String postId, String negotiationId, Long userId, Long organizationId) {}
+    @Schema(description = "Identifier of the created post", example = "post-1") String postId,
+    @Schema(
+            description = "Identifier of the parent negotiation",
+            example = "ab222d9c-4567-4c9a-8f0e-123456789abc")
+        String negotiationId,
+    @Schema(description = "Identifier of the user that created the post", example = "1000")
+        Long userId,
+    @Schema(
+            description = "Optional identifier of the organization context",
+            nullable = true,
+            example = "2000")
+        Long organizationId) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationResourceStateUpdatedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationResourceStateUpdatedWebhookEvent.java
@@ -2,6 +2,7 @@ package eu.bbmri_eric.negotiator.webhook.event;
 
 import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceEvent;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Webhook data payload for a resource state transition in a negotiation.
@@ -12,9 +13,25 @@ import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationRe
  * @param toState new resource state
  * @param event resource-state-machine event that triggered the transition
  */
+@WebhookEventDoc(
+    summary = "Negotiation resource state changed",
+    description =
+        "Sent when the state of a resource within a negotiation changes through the state machine.")
+@Schema(description = "Webhook data payload for a negotiation resource state transition.")
 record NegotiationResourceStateUpdatedWebhookEvent(
-    String negotiationId,
-    String resourceId,
-    NegotiationResourceState fromState,
-    NegotiationResourceState toState,
-    NegotiationResourceEvent event) {}
+    @Schema(
+            description = "Identifier of the parent negotiation",
+            example = "ab222d9c-4567-4c9a-8f0e-123456789abc")
+        String negotiationId,
+    @Schema(
+            description = "Identifier of the affected resource",
+            example = "dcba1234-5678-4c9a-8f0e-123456789abc")
+        String resourceId,
+    @Schema(description = "Source resource state before transition", example = "SUBMITTED")
+        NegotiationResourceState fromState,
+    @Schema(description = "Target resource state after transition", example = "RESOURCE_AVAILABLE")
+        NegotiationResourceState toState,
+    @Schema(
+            description = "State-machine event that triggered the transition",
+            example = "MARK_AS_AVAILABLE")
+        NegotiationResourceEvent event) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationResourceUpdatedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationResourceUpdatedWebhookEvent.java
@@ -1,8 +1,16 @@
 package eu.bbmri_eric.negotiator.webhook.event;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Webhook data payload for newly added resources in a negotiation.
  *
  * @param negotiationId identifier of the affected negotiation
  */
-record NegotiationResourceUpdatedWebhookEvent(String negotiationId) {}
+@WebhookEventDoc(
+    summary = "Negotiation resources added",
+    description = "Sent when one or more resources are added to an existing negotiation.")
+@Schema(description = "Webhook data payload for newly added negotiation resources.")
+record NegotiationResourceUpdatedWebhookEvent(
+    @Schema(description = "Identifier of the affected negotiation", example = "negotiation-4")
+        String negotiationId) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationStateUpdatedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationStateUpdatedWebhookEvent.java
@@ -2,6 +2,7 @@ package eu.bbmri_eric.negotiator.webhook.event;
 
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationEvent;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Webhook data payload for a negotiation state transition.
@@ -11,8 +12,16 @@ import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.Negotiatio
  * @param toState target negotiation state after transition
  * @param event state-machine event that triggered the transition
  */
+@WebhookEventDoc(
+    summary = "Negotiation state changed",
+    description = "Sent when the negotiation lifecycle state transitions to a new state.")
+@Schema(description = "Webhook data payload for a negotiation state transition.")
 record NegotiationStateUpdatedWebhookEvent(
-    String negotiationId,
-    NegotiationState fromState,
-    NegotiationState toState,
-    NegotiationEvent event) {}
+    @Schema(description = "Identifier of the affected negotiation", example = "negotiation-2")
+        String negotiationId,
+    @Schema(description = "Source state before transition", example = "DRAFT")
+        NegotiationState fromState,
+    @Schema(description = "Target state after transition", example = "SUBMITTED")
+        NegotiationState toState,
+    @Schema(description = "State-machine event that triggered the transition", example = "SUBMIT")
+        NegotiationEvent event) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/PingWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/PingWebhookEvent.java
@@ -1,8 +1,15 @@
 package eu.bbmri_eric.negotiator.webhook.event;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Webhook data payload for a ping delivery.
  *
  * @param webhookId identifier of the target webhook
  */
-record PingWebhookEvent(Long webhookId) {}
+@WebhookEventDoc(
+    summary = "Ping delivery",
+    description = "Sent when a webhook ping is manually triggered from the API.")
+@Schema(description = "Webhook data payload for a ping delivery.")
+record PingWebhookEvent(
+    @Schema(description = "Identifier of the target webhook", example = "1") Long webhookId) {}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventDoc.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventDoc.java
@@ -1,0 +1,19 @@
+package eu.bbmri_eric.negotiator.webhook.event;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Metadata used for generated OpenAPI webhook documentation. */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface WebhookEventDoc {
+  /** Human-readable webhook summary shown in OpenAPI operation docs. */
+  String summary();
+
+  /** Optional detailed webhook description shown in OpenAPI docs. */
+  String description() default "";
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapper.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapper.java
@@ -9,6 +9,7 @@ import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.Negotiatio
 import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.ResourceStateChangeEvent;
 import eu.bbmri_eric.negotiator.post.NewPostEvent;
 import java.time.Instant;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
 import org.springframework.context.ApplicationEvent;
@@ -79,6 +80,20 @@ public class WebhookEventMapper {
       return Optional.empty();
     }
     return Optional.of(eventDefinition.toEnvelope(event, objectMapper));
+  }
+
+  /**
+   * Lists all webhook event types and payload DTO classes that should be documented in OpenAPI.
+   *
+   * @return immutable map of webhook event type to payload DTO class
+   */
+  public Map<WebhookEventType, Class<?>> documentedPayloadTypes() {
+    Map<WebhookEventType, Class<?>> payloadTypes = new EnumMap<>(WebhookEventType.class);
+    for (WebhookEventDefinition<?, ?> definition : eventDefinitions.values()) {
+      payloadTypes.put(definition.eventType(), definition.dataType());
+    }
+    payloadTypes.put(WebhookEventType.PING, PingWebhookEvent.class);
+    return Map.copyOf(payloadTypes);
   }
 
   private record WebhookEventDefinition<S extends ApplicationEvent, T>(

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapperTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapperTest.java
@@ -13,6 +13,7 @@ import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationRe
 import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.ResourceStateChangeEvent;
 import eu.bbmri_eric.negotiator.post.NewPostEvent;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -135,5 +136,27 @@ class WebhookEventMapperTest {
                 NegotiationResourceState.SUBMITTED,
                 NegotiationResourceState.RESOURCE_AVAILABLE,
                 NegotiationResourceEvent.MARK_AS_AVAILABLE));
+  }
+
+  @Test
+  void documentedPayloadTypes_containsAllWebhookPayloads() {
+    Map<WebhookEventType, Class<?>> documentedPayloads = mapper.documentedPayloadTypes();
+
+    assertThat(documentedPayloads)
+        .containsEntry(
+            WebhookEventType.NEGOTIATION_INFO_UPDATED, NegotiationInfoUpdatedWebhookEvent.class)
+        .containsEntry(
+            WebhookEventType.NEGOTIATION_STATE_UPDATED, NegotiationStateUpdatedWebhookEvent.class)
+        .containsEntry(WebhookEventType.NEGOTIATION_ADDED, NegotiationAddedWebhookEvent.class)
+        .containsEntry(
+            WebhookEventType.NEGOTIATION_RESOURCE_ADDED,
+            NegotiationResourceUpdatedWebhookEvent.class)
+        .containsEntry(
+            WebhookEventType.NEGOTIATION_POST_ADDED, NegotiationPostAddedWebhookEvent.class)
+        .containsEntry(
+            WebhookEventType.NEGOTIATION_RESOURCE_STATE_UPDATED,
+            NegotiationResourceStateUpdatedWebhookEvent.class)
+        .containsEntry(WebhookEventType.PING, PingWebhookEvent.class)
+        .hasSize(7);
   }
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -91,6 +91,7 @@ export default defineConfig({
                     {text: 'Deployment', link: '/deployment'},
                     {text: 'Notifications', link: '/notifications'},
                     {text: 'REST API', link: '/REST'},
+                    {text: 'Webhooks API', link: '/webhooks'},
                     {text: 'Authentication and Authorization', link: '/auth'},
                     {text: 'Logging', link: '/logging'},
                     {text: 'Lifecycle', link: '/lifecycle'},

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -61,40 +61,8 @@ The requirement will be triggered when a Representative tries to advance the Sta
 
 ## Webhooks
 
-The Negotiator uses a webhook system to allow external systems to be notified of events that occur within the
-Negotiator.
-This guide provides an overview of how to set up and use webhooks with the Negotiator.
-
-### Setting Up Webhooks
-
-To set up webhooks, you need to provide a URL endpoint that the Negotiator can send HTTP POST requests to when certain
-events occur.
-You can do this by going to the Admin Settings -> Webhooks section in the Negotiator UI.
-There, you can add a new webhook by providing the following information:
-
-- **Webhook URL**: The URL endpoint that will receive the webhook notifications.
-- **SSL Verification**: Whether to verify the SSL certificate of the webhook URL. This is enabled by default and it is
-  recommended to keep it enabled for security reasons.
-- **Active**: Whether the webhook is active or not. You can disable a webhook if you want to temporarily stop receiving
-  notifications without deleting it.
-- **Webhook Secret (optional)**: Secret values must use the format `whsec_<base64>`. The encoded part must decode to
-  24-64 bytes. Only standard base64 accepted.
-  You can generate a suitable value with:
-
-  ```bash
-  openssl rand -base64 32
-  ```
-
-  Then prefix the generated value with `whsec_` before saving it (for example, `whsec_<generated_value>`).
-
-> [!NOTE]
-> Webhook secrets are write-only and stored encrypted at rest. The plaintext value is never returned by the API or UI.
-
-> [!WARNING]  
-> We currently do not support authentication for webhooks. This means that anyone who knows the webhook URL can send
-> requests to it.
-> Please ensure that your webhook URL is not publicly accessible or use a firewall to restrict access to it. If you
-> would like us to implement authentication for webhooks, please let us know.
+Webhooks notify external systems when events occur.
+For setup and technical details, see [Managing webhooks](/webhooks#managing-webhooks).
 
 ## Templates
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -91,7 +91,7 @@ the [application file](https://github.com/BBMRI-ERIC/negotiator/blob/master/back
 | `NEGOTIATOR_EMAIL_FREQUENCYCRONEXPRESSION`            | Cron expression for email frequency.                                                                    | `"0 0 * * * *"`                                                              |
 | `NEGOTIATOR_EMAILADDRESS`                             | Email address from which emails are sent                                                                | "BBMRI-ERIC Negotiator <noreply@bbmri-eric.eu>"                              |
 | `NEGOTIATOR_WEBHOOK_SECRET_ENCRYPTION_ENABLED`       | Enables encryption at rest for webhook secrets. If `true`, master key must be configured.                | `true`                                                                         |
-| `NEGOTIATOR_WEBHOOK_SECRET_ENCRYPTION_MASTER_KEY`    | Current webhook secret master key (mapped to `negotiator.webhook.secret-encryption.master-key`).       | `""`                                                                          |
+| `NEGOTIATOR_WEBHOOK_SECRET_ENCRYPTION_MASTER_KEY`    | Current webhook secret master key (mapped to `negotiator.webhook.secret-encryption.master-key`). See [Generating a webhook master secret](#generating-a-webhook-master-secret). | `""`                                                                          |
 | `NEGOTIATOR_WEBHOOK_SECRET_ENCRYPTION_PREVIOUS_MASTER_KEY` | Previous webhook secret master key used only for key rotation (`rotate-secrets` profile).         | `""`                                                                          |
 | `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_AUDIENCES` | OAuth2 Resource Audience(s); see [aud claim](https://datatracker.ietf.org/doc/html/rfc8693#section-3.1) | "https://negotiator.bbmri-eric.eu,negotiator-api"                            |
 
@@ -100,6 +100,21 @@ the [application file](https://github.com/BBMRI-ERIC/negotiator/blob/master/back
 > and REPRESENTATIVE/NETWORK MANAGER roles are assigned inside the Negotiator. Previous variables like
 > `NEGOTIATOR_AUTHORIZATION_RESEARCHERCLAIMVALUE` and `NEGOTIATOR_AUTHORIZATION_BIOBANKERCLAIMVALUE` are deprecated and
 > not used by current versions.
+
+### Generating a webhook master secret
+
+When webhook secret encryption is enabled, set
+`NEGOTIATOR_WEBHOOK_SECRET_ENCRYPTION_MASTER_KEY` to a securely generated 32-byte value.
+
+Recommended generation command:
+
+```bash
+openssl rand -hex 32
+```
+
+This command returns 64 hex characters (32 bytes). Use that value directly as the environment variable value.
+
+Store this key in your secret manager and do not commit it to source control.
 
 ### Webhook secret encryption behavior
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -34,7 +34,7 @@ All webhook operations and payload schemas are documented under the `Webhooks` s
 
 ## Headers
 
-Negotiator sends the standard webhook metadata headers (HTTP header names are case-insensitive):
+Negotiator sends the standard webhook metadata headers (HTTP header names are case-insensitive). `Webhook-Signature` is included only when a webhook secret is configured:
 
 | Header name         | Description                                              |
 |---------------------|----------------------------------------------------------|

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,154 @@
+# Webhooks API
+
+The Negotiator uses webhooks to notify external systems when specific events happen.
+Webhook messages are aligned with the [Standard Webhooks](https://www.standardwebhooks.com/)
+guidelines and use HTTP `POST` requests with JSON payloads.
+
+For the full interoperability specification, see the official
+[Standard Webhooks specification](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md).
+
+## Event types and payloads
+
+Event types follow a full-stop delimited format, for example `negotiation.state.updated`.
+
+Negotiator sends webhook JSON payload with this top-level structure:
+
+- `type`: the event type identifier
+- `timestamp`: when the event occurred (ISO 8601 UTC timestamp)
+- `data`: event-specific fields
+
+Example `ping` payload:
+
+```json
+{
+	"type": "ping",
+	"timestamp": "2026-04-29T10:15:30Z",
+	"data": {
+		"webhookId": 42
+	}
+}
+```
+
+All webhook operations and payload schemas are documented under the `Webhooks` section in the
+[Negotiator OpenAPI documentation](https://negotiator-v3.bbmri-eric.eu/api/swagger-ui/index.html).
+
+## Headers
+
+Negotiator sends the standard webhook metadata headers (HTTP header names are case-insensitive):
+
+| Header name         | Description                                              |
+|---------------------|----------------------------------------------------------|
+| `Webhook-Id`        | Unique message identifier. Useful as an idempotency key. |
+| `Webhook-Timestamp` | Unix timestamp (seconds) for this delivery attempt.      |
+| `Webhook-Signature` | Signature value(s) used to verify authenticity.          |
+
+Example:
+
+```http
+Webhook-Id: msg_12345
+Webhook-Timestamp: 1777457730
+Webhook-Signature: v1,BASE64_SIGNATURE
+```
+
+## Webhook signatures
+
+Negotiator signs webhook messages with HMAC-SHA256 when a webhook secret is configured.
+
+Secret format:
+
+- `whsec_<base64>`
+- Base64 part must decode to 24-64 bytes
+
+Signature input follows the Standard Webhooks format:
+
+```text
+webhook-id.webhook-timestamp.raw-body
+```
+
+Important verification rules:
+
+- Verify against the raw request body bytes (do not parse and re-serialize JSON before verification)
+- Enforce timestamp tolerance to reduce replay risk
+- Use `Webhook-Id` as an idempotency key
+
+Example using the official Standard Webhooks JavaScript reference library:
+
+```javascript
+import { Webhook } from "standardwebhooks"
+
+const wh = new Webhook(process.env.NEGOTIATOR_WEBHOOK_SECRET)
+
+wh.verify(rawBody, {
+	"webhook-id": req.headers["webhook-id"],
+	"webhook-timestamp": req.headers["webhook-timestamp"],
+	"webhook-signature": req.headers["webhook-signature"],
+})
+```
+
+Reference libraries are available for JavaScript/TypeScript, Java/Kotlin, Python, and other languages in the
+Standard Webhooks repository.
+
+## Managing webhooks
+
+Webhooks are managed in the Negotiator UI by administrators.
+
+1. Log in with administrator privileges.
+2. Open **Admin Settings -> Webhooks**.
+3. Add or edit a webhook with the following fields:
+	 - **Webhook URL**: destination endpoint receiving HTTP POST requests.
+	 - **Webhook Secret (optional)**: signing secret in the form `whsec_<base64>`.
+		 Generate key material with:
+
+		 ```bash
+		 openssl rand -base64 32
+		 ```
+
+		 Then prefix the result with `whsec_`.
+	 - **SSL Verification**: when enabled, TLS certificate validation is enforced.
+	 - **Active**: enables or disables deliveries without deleting the webhook.
+
+4. Use **Test** to send a `ping` delivery and validate endpoint configuration.
+
+## Delivery History
+The Delivery History tab shows recent delivery attempts for each webhook.
+
+For each attempt, you can inspect:
+
+- Delivery status (success/failure)
+- Event type
+- Delivery identifier
+- Timestamp
+- Response status code (if available)
+- Error message (if delivery failed)
+- Delivered JSON body
+
+Deliveries are shown with newest first. Negotiator stores up to the latest 100 deliveries per webhook.
+
+## Redeliveries
+
+If a delivery failed or a consumer had downtime, you can trigger a manual redelivery from Delivery History.
+To do that, click **Redeliver** on a delivery entry in the delivery history of a webhooks.
+
+Behavior:
+- Reuses the same payload and event type as the selected source delivery
+- Creates a new delivery attempt record
+- Re-signs the request with current signing configuration
+- Preserves root delivery identity for traceability and idempotent consumer handling
+
+## Best practices
+
+Follow these practices to improve security and reliability when receiving webhook deliveries.
+
+- Use a webhook secret and verify the webhook signature for every request. See [Webhook signatures](#webhook-signatures).
+- Keep SSL verification enabled. Disabling SSL verification should be limited to controlled local testing.
+- Ensure your endpoint responds with a `2xx` status within 10 seconds.
+- Design your receiver around the delivery time limits used by Negotiator:
+	- connect timeout: 2 seconds
+	- response timeout: 8 seconds
+- Use the `Webhook-Id` header as an idempotency key:
+	- store recently seen IDs for a short period
+	- ignore duplicate deliveries to reduce replay risk
+- Process webhook payloads asynchronously:
+	- validate and acknowledge quickly
+	- enqueue background processing
+	- avoid long-running synchronous work before sending the `2xx` response

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -11,7 +11,7 @@ For the full interoperability specification, see the official
 
 Event types follow a full-stop delimited format, for example `negotiation.state.updated`.
 
-Negotiator sends webhook JSON payload with this top-level structure:
+Negotiator sends a webhook JSON payload with this top-level structure:
 
 - `type`: the event type identifier
 - `timestamp`: when the event occurred (ISO 8601 UTC timestamp)

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -127,7 +127,7 @@ Deliveries are shown with newest first. Negotiator stores up to the latest 100 d
 ## Redeliveries
 
 If a delivery failed or a consumer had downtime, you can trigger a manual redelivery from Delivery History.
-To do that, click **Redeliver** on a delivery entry in the delivery history of a webhooks.
+To do that, click **Redeliver** on a delivery entry in the delivery history of a webhook.
 
 Behavior:
 - Reuses the same payload and event type as the selected source delivery

--- a/frontend/src/views/WebhooksListPage.vue
+++ b/frontend/src/views/WebhooksListPage.vue
@@ -12,7 +12,7 @@
           Webhooks allow external services to be notified when certain events happen. When the
           specified events occur, we send a POST request to each URL provided. Learn more in our
           <a
-            href="https://bbmri-eric.github.io/negotiator/administrator#webhooks"
+            href="https://bbmri-eric.github.io/negotiator/webhooks#managing-webhooks"
             target="_blank"
             rel="noopener noreferrer"
             >Webhooks Documentation</a


### PR DESCRIPTION
### Description:

This pull request introduces automated generation of OpenAPI documentation for webhook endpoints and enhances the documentation of webhook events and headers. The changes add a factory to dynamically generate OpenAPI webhook paths, annotate webhook event payloads and headers for improved API documentation, and update the Swagger configuration to include webhook endpoints.

**OpenAPI Webhook Documentation Generation:**

* Added `WebhookOpenApiDocumentationFactory`, a component that discovers webhook event types and headers, and programmatically generates OpenAPI path documentation for all webhook events, including schemas and header parameters.
* Updated `SwaggerConfig` to use `WebhookOpenApiDocumentationFactory` to add webhook paths and schemas to the OpenAPI definition, ensuring all webhooks are documented in the API spec. [[1]](diffhunk://#diff-6f338a0daececc1c25517ca53ebe29ef5be9f972f33d735a19565ed5446d814fR3-R13) [[2]](diffhunk://#diff-6f338a0daececc1c25517ca53ebe29ef5be9f972f33d735a19565ed5446d814fL27-R52) [[3]](diffhunk://#diff-6f338a0daececc1c25517ca53ebe29ef5be9f972f33d735a19565ed5446d814fL55-R77)

**Webhook Header Documentation:**

* Introduced the `@WebhookHeaderDoc` annotation and applied it to all webhook header constants in `WebhookHeaders`, providing human-readable descriptions, required status, and example values for OpenAPI documentation. [[1]](diffhunk://#diff-74bc5bbe1187542069d194e9114fc7062668af801f38626e84292b65159014a0R1-R22) [[2]](diffhunk://#diff-82d39eaf3a0ac05e00739a1d443bcb55b17ac18bb42dc8ba2eb725b4e542c082R8-R23)

**Webhook Event Payload Documentation:**

* Annotated all webhook event payload records (such as `NegotiationAddedWebhookEvent`, `NegotiationInfoUpdatedWebhookEvent`, etc.) with `@WebhookEventDoc` and OpenAPI `@Schema` annotations, supplying summaries, detailed descriptions, and field-level documentation including examples. [[1]](diffhunk://#diff-ec8badc2ae1075ee928182692e4200a8032461b786125842b9444c0f524064d5R3-R16) [[2]](diffhunk://#diff-daa7f357bb059c73c68f06273464a45b36ece2e70146c9b0936752bdf4ef7478R3-R16) [[3]](diffhunk://#diff-8fd142f4e1dddad37468b70e537ccc0886a2f9c0aa59f6bf7edd875acf0ccd8aR3-R4) [[4]](diffhunk://#diff-8fd142f4e1dddad37468b70e537ccc0886a2f9c0aa59f6bf7edd875acf0ccd8aR13-R29) [[5]](diffhunk://#diff-93414470b4ef616f92928c5d998a530936e9d3cb191ea0c8d639e2eb40c0e5f6R5) [[6]](diffhunk://#diff-93414470b4ef616f92928c5d998a530936e9d3cb191ea0c8d639e2eb40c0e5f6R16-R36) [[7]](diffhunk://#diff-bae697adc20d067c2d469aeed7f98f14d951438fa45baf11815389d4343927d0R3-R16) [[8]](diffhunk://#diff-02b1fa395d06b95a98cdafde0f4a1c5ccede7ee4b241d06b19478cb76984ee33R5) [[9]](diffhunk://#diff-02b1fa395d06b95a98cdafde0f4a1c5ccede7ee4b241d06b19478cb76984ee33R15-R26) [[10]](diffhunk://#diff-1e0801954ec6985dd7e58049410c1b77df92dfb5ed1186424908b3346c15c2b1R3-R15)
### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
