### PR TITLE
fix: fix docker-compose postgres healthcheck command format

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -38,7 +38,7 @@ services:
       - POSTGRES_PASSWORD=negotiator
       - POSTGRES_DB=negotiator
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U negotiator -d negotiator"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 5s
       timeout: 60s
       retries: 5

--- a/compose.yml
+++ b/compose.yml
@@ -38,7 +38,7 @@ services:
       - POSTGRES_PASSWORD=negotiator
       - POSTGRES_DB=negotiator
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready", "-d", "negotiator" ]
+      test: ["CMD-SHELL", "pg_isready -U negotiator -d negotiator"]
       interval: 5s
       timeout: 60s
       retries: 5


### PR DESCRIPTION
### Description:

fix(docker): correct postgres healthcheck syntax

Fixes the `FATAL: role "root" does not exist` error caused by an 
incorrectly formatted `CMD-SHELL` array. 

By wrapping the entire `pg_isready` command into a single string argument, 
Docker Compose now correctly passes the user flags (`-U negotiator`) to 
the shell execution environment instead of dropping them and defaulting to root.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
