### PR TITLE
feat: display id and uidd on pdf export

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/pdf/NegotiationPdfServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/pdf/NegotiationPdfServiceImpl.java
@@ -165,7 +165,8 @@ public class NegotiationPdfServiceImpl implements NegotiationPdfService {
       context.setVariable("authorName", negotiation.getCreatedBy().getName());
       context.setVariable("authorEmail", negotiation.getCreatedBy().getEmail());
       context.setVariable("authorInstitution", negotiation.getCreatedBy().getOrganization());
-      context.setVariable("negotiationId", negotiation.getId());
+      context.setVariable("negotiationId", negotiation.getDisplayId());
+      context.setVariable("negotiationUuid", negotiation.getId());
       context.setVariable("negotiationTitle", negotiation.getTitle());
       context.setVariable("negotiationCreatedAt", negotiation.getCreationDate());
       context.setVariable("negotiationStatus", negotiation.getCurrentState());

--- a/backend/src/main/resources/templates/PDF_NEGOTIATION_SUMMARY.html
+++ b/backend/src/main/resources/templates/PDF_NEGOTIATION_SUMMARY.html
@@ -262,6 +262,10 @@
             <span class="detail-value" th:text="${negotiationId}">Not specified</span>
         </div>
         <div class="detail-row">
+            <span class="detail-label">Negotiation UUID:</span>
+            <span class="detail-value" th:text="${negotiationUuid}">Not specified</span>
+        </div>
+        <div class="detail-row">
             <span class="detail-label">Requester:</span>
             <span class="detail-value" th:text="${authorName}">Not specified</span>
         </div>
@@ -306,7 +310,11 @@
         </tr>
         <tr>
             <td class="label-col">Negotiation ID:</td>
-            <td class="value-col font-bold" th:text="${negotiationId}">Not specified</td>
+            <td class="value-col" th:text="${negotiationId}">Not specified</td>
+        </tr>
+        <tr>
+            <td class="label-col">Negotiation UUID:</td>
+            <td class="value-col" th:text="${negotiationUuid}">Not specified</td>
         </tr>
         <tr>
             <td class="label-col">Project Title:</td>


### PR DESCRIPTION
### Description:

- Added a separate Negotiation UUID field in the PDF summary.
- Kept Negotiation ID as a separate field.
- Updated backend PDF context to pass both values:

1. negotiationId now resolves to display ID when available, with fallback to entity ID.
2. negotiationUuid is passed explicitly as the entity UUID.

- This ensures the PDF clearly shows both human-readable ID and technical UUID for traceability.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
