### PR TITLE
feat(forms): reuse shared capitalizeAllWords for access form labels

### DIFF
--- a/frontend/src/components/OrganizationListItem.vue
+++ b/frontend/src/components/OrganizationListItem.vue
@@ -188,9 +188,7 @@
                   <span v-if="resource.accessForm">
                     {{ resource.accessForm.name }}
                   </span>
-                  <span v-else class="text-warning">
-                    None assigned
-                  </span>
+                  <span v-else class="text-warning"> None assigned </span>
                 </small>
               </div>
             </div>

--- a/frontend/src/components/form-components/AccessFormSection.vue
+++ b/frontend/src/components/form-components/AccessFormSection.vue
@@ -2,7 +2,7 @@
   <div class="access-form-section d-flex flex-column">
     <div class="section mb-5">
       <h2 class="fw-bold">
-        {{ accessFormWithPayloadSection.label }}
+        {{ capitalizeAllWords(accessFormWithPayloadSection.label) }}
       </h2>
       <p class="mb-0">{{ accessFormWithPayloadSection.description }}</p>
     </div>
@@ -23,7 +23,7 @@
       "
     >
       <label class="form-label" :class="{ required: element.required }">
-        {{ element.label }}
+        {{ capitalizeAllWords(element.label) }}
       </label>
       <span v-if="element.description" class="ms-2 text-muted">
         <i
@@ -221,7 +221,7 @@ import { useNegotiationFormStore } from '../../store/negotiationForm'
 import { useNotificationsStore } from '../../store/notifications'
 
 import fileExtensions from '@/config/uploadFileExtensions.js'
-import { isFileExtensionsSupported } from '../../composables/utils.js'
+import { capitalizeAllWords, isFileExtensionsSupported } from '../../composables/utils.js'
 
 const accessFormWithPayloadSection = defineModel('accessFormWithPayloadSection')
 const negotiationReplacedAttachmentsID = defineModel('negotiationReplacedAttachmentsID')

--- a/frontend/src/composables/utils.js
+++ b/frontend/src/composables/utils.js
@@ -2,6 +2,15 @@ export function capitalizeFirstLetter(val) {
   return String(val).charAt(0).toUpperCase() + String(val).slice(1)
 }
 
+export function capitalizeAllWords(val) {
+  if (!val) return ''
+  return val
+    .split(/[\s_-]+/)
+    .filter(Boolean) // remove empty strings from edge cases
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ')
+}
+
 export function transformStatus(status) {
   if (status === 'SUBMITTED') {
     return 'UNDER REVIEW'

--- a/frontend/src/composables/utils.js
+++ b/frontend/src/composables/utils.js
@@ -3,8 +3,9 @@ export function capitalizeFirstLetter(val) {
 }
 
 export function capitalizeAllWords(val) {
-  if (!val) return ''
-  return val
+  const str = String(val ?? '').trim()
+  if (!str) return ''
+  return str
     .split(/[\s_-]+/)
     .filter(Boolean) // remove empty strings from edge cases
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())


### PR DESCRIPTION
### Description:

Description:

- Replaced the local label-capitalization logic with the shared capitalizeAllWords helper.
- Updated access form field label rendering to use the common utility.
- Removed duplicate formatting code from the component to improve consistency and maintainability.
- This ensures form field names are capitalized uniformly across the app.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
