### PR TITLE
chore(deps): bump commons-validator from 1.7 to 1.10.1

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -27,7 +27,7 @@
         <awaitility.version>4.3.0</awaitility.version>
         <commons-csv.version>1.14.0</commons-csv.version>
         <commons-math3.version>3.6.1</commons-math3.version>
-        <commons-validator.version>1.7</commons-validator.version>
+        <commons-validator.version>1.10.1</commons-validator.version>
         <docx4j.version>11.5.12</docx4j.version>
         <flying-saucer.version>9.5.1</flying-saucer.version>
         <gson.version>2.12.1</gson.version>


### PR DESCRIPTION
## Summary

Update `commons-validator` from `1.7` to `1.10.1`.

## Changes

- Updated `commons-validator.version` in `backend/pom.xml`

## Note
Email unit tests should cover regressions to email validation which is the only call-path for this dependency