### PR TITLE
chore: add Docker as dependabot package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,13 @@ updates:
       - "tmilost"
     schedule:
       interval: "monthly"
+  # Maintain dependencies for Docker base images
+  - package-ecosystem: "docker"
+    directories:
+      - "/backend"
+      - "/frontend"
+    schedule:
+      interval: "monthly"
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`


### PR DESCRIPTION
### Description:

Adds `docker` as a package-ecosystem in `.github/dependabot.yml` so that Dependabot will open automated PRs when base image versions in our Dockerfiles fall behind. Covers both `/backend` and `/frontend` on the existing monthly schedule.

### Checklist:

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)