### PR TITLE
chore(frontend): migrate nginx base image from bitnamilegacy to nginxinc/nginx-unprivileged

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,13 +4,12 @@ COPY . .
 RUN yarn install
 RUN yarn build
 
-FROM bitnamilegacy/nginx:1.24 AS production-stage
+FROM nginxinc/nginx-unprivileged:1.31.2-perl AS production-stage
+ARG NGINX_UID=101
 WORKDIR /app
-COPY nginx.conf /opt/bitnami/nginx/conf/server_blocks/my_server_block.conf
-COPY src/assets/scss /app/assets
-COPY start.sh .
-COPY --from=build-stage /app/dist .
-USER 0
-RUN chmod -R g+rwx /app
-USER 1001
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --chown=${NGINX_UID}:${NGINX_UID} src/assets/scss /app/assets
+COPY --chown=${NGINX_UID}:${NGINX_UID} start.sh .
+COPY --chown=${NGINX_UID}:${NGINX_UID} --from=build-stage /app/dist .
+USER ${NGINX_UID}
 CMD ["./start.sh"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN yarn install
 RUN yarn build
 
-FROM nginxinc/nginx-unprivileged:1.31.2-perl AS production-stage
+FROM nginxinc/nginx-unprivileged:1.31.2-perl@sha256:1580f7ab8afdc0ebfdd2a6f0e6223354c12f0bddb5b66215c2c88f071adabb89 AS production-stage
 ARG NGINX_UID=101
 WORKDIR /app
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
### Description:
This pull request updates the production Docker image in `frontend/Dockerfile` to use a more secure, unprivileged NGINX base image and adjusts file copying and permissions accordingly. The changes improve security and compatibility with modern container best practices.

**Docker base image and permissions:**

* Switched the production base image from `bitnamilegacy/nginx:1.24` to `nginxinc/nginx-unprivileged:1.31.2-perl`, which runs as a non-root user by default for improved security.
* Updated file copy commands to use `--chown` with the `NGINX_UID` build argument, ensuring all files are owned by the expected unprivileged user inside the container.
* Changed the NGINX configuration path to `/etc/nginx/conf.d/default.conf` to match the new base image's conventions.
* Removed explicit `chmod` commands in favor of setting the user via the `USER` directive and file ownership at copy time.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
