### PR TITLE
chore: update and pin backend base images

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build jar file with dependencies
-FROM maven:3.9.9-eclipse-temurin-21 AS build_image
+FROM maven:3.9.16-eclipse-temurin-21-noble@sha256:d7e7f57407437c014571f1ad5a9955f03fc3edcb1d964067ef351fa38e798665 AS build_image
 ARG ARTIFACT_VERSION=unknown
 COPY src /app/src
 COPY pom.xml /app
@@ -9,7 +9,7 @@ RUN mvn --quiet -B clean package -Dmaven.test.skip=true
 
 
 # Runtime image
-FROM eclipse-temurin:21-jre-jammy@sha256:daebe9ae03913ec4b2dadd8df60f3ea3df1aa6108fecd5d324d000bdd5c4c816
+FROM eclipse-temurin:21-jre-noble@sha256:1038345f7b7211c290148801b92d66abe5588d4acd6820994df43b883cdfc04c
 RUN mkdir /var/log/negotiator && chown 1001 /var/log/negotiator
 RUN mkdir -p /app/config/templates && chown 1001 /app/config/templates
 USER 1001


### PR DESCRIPTION
### Description:

This pull request updates the base images used in the `backend/Dockerfile` to newer versions based on Ubuntu Noble, ensuring improved compatibility and security.

**Docker base image updates:**

* Updated the build image from `maven:3.9.9-eclipse-temurin-21` to `maven:3.9.16-eclipse-temurin-21-noble`, referencing a specific digest for reproducibility.
* Updated the runtime image from `eclipse-temurin:21-jre-jammy` to `eclipse-temurin:21-jre-noble`, also referencing a specific digest.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [ ] I have performed a self-review of my code
- [ ] I have made my code as simple as possible
- [ ] I have removed all commented code
- [ ] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
