### PR TITLE
feat: option to use a simplified resource state machine

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/state_machine/resource/SimplifiedResourceStateMachineConfig.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/state_machine/resource/SimplifiedResourceStateMachineConfig.java
@@ -14,11 +14,12 @@ import org.springframework.statemachine.config.builders.StateMachineTransitionCo
 import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.security.SecurityRule;
 
-/** Configuration for the Resource State Machine. */
+/** Simplified resource state machine active under the minimal-workflow Spring profile. */
 @Configuration
-@Profile("!minimal-workflow")
+@Profile("minimal-workflow")
 @EnableStateMachine(name = "resourceStateMachine")
-public class ResourceStateMachineConfig extends StateMachineConfigurerAdapter<String, String> {
+public class SimplifiedResourceStateMachineConfig
+    extends StateMachineConfigurerAdapter<String, String> {
 
   @Override
   public void configure(StateMachineConfigurationConfigurer<String, String> config)
@@ -58,62 +59,14 @@ public class ResourceStateMachineConfig extends StateMachineConfigurerAdapter<St
         .and()
         .withExternal()
         .source(NegotiationResourceState.REPRESENTATIVE_CONTACTED.name())
-        .event(NegotiationResourceEvent.MARK_AS_CHECKING_AVAILABILITY.name())
-        .target(NegotiationResourceState.CHECKING_AVAILABILITY.name())
+        .event(NegotiationResourceEvent.GRANT_ACCESS_TO_RESOURCE.name())
+        .target(NegotiationResourceState.RESOURCE_MADE_AVAILABLE.name())
         .secured("isRepresentative", SecurityRule.ComparisonType.ALL)
         .and()
         .withExternal()
         .source(NegotiationResourceState.REPRESENTATIVE_CONTACTED.name())
         .event(NegotiationResourceEvent.STEP_AWAY.name())
         .target(NegotiationResourceState.RESOURCE_UNAVAILABLE.name())
-        .secured("isRepresentative", SecurityRule.ComparisonType.ALL)
-        .and()
-        .withExternal()
-        .source(NegotiationResourceState.CHECKING_AVAILABILITY.name())
-        .event(NegotiationResourceEvent.MARK_AS_UNAVAILABLE.name())
-        .target(NegotiationResourceState.RESOURCE_UNAVAILABLE.name())
-        .secured("isRepresentative", SecurityRule.ComparisonType.ALL)
-        .and()
-        .withExternal()
-        .source(NegotiationResourceState.CHECKING_AVAILABILITY.name())
-        .event(NegotiationResourceEvent.MARK_AS_CURRENTLY_UNAVAILABLE_BUT_WILLING_TO_COLLECT.name())
-        .target(NegotiationResourceState.RESOURCE_UNAVAILABLE_WILLING_TO_COLLECT.name())
-        .secured("isRepresentative", SecurityRule.ComparisonType.ALL)
-        .and()
-        .withExternal()
-        .source(NegotiationResourceState.CHECKING_AVAILABILITY.name())
-        .event(NegotiationResourceEvent.MARK_AS_AVAILABLE.name())
-        .target(NegotiationResourceState.RESOURCE_AVAILABLE.name())
-        .secured("isRepresentative", SecurityRule.ComparisonType.ALL)
-        .and()
-        .withExternal()
-        .source(NegotiationResourceState.RESOURCE_AVAILABLE.name())
-        .event(NegotiationResourceEvent.INDICATE_ACCESS_CONDITIONS.name())
-        .target(NegotiationResourceState.ACCESS_CONDITIONS_INDICATED.name())
-        .secured("isRepresentative", SecurityRule.ComparisonType.ALL)
-        .and()
-        .withExternal()
-        .source(NegotiationResourceState.RESOURCE_UNAVAILABLE_WILLING_TO_COLLECT.name())
-        .event(NegotiationResourceEvent.INDICATE_ACCESS_CONDITIONS.name())
-        .target(NegotiationResourceState.ACCESS_CONDITIONS_INDICATED.name())
-        .secured("isRepresentative", SecurityRule.ComparisonType.ALL)
-        .and()
-        .withExternal()
-        .source(NegotiationResourceState.ACCESS_CONDITIONS_INDICATED.name())
-        .event(NegotiationResourceEvent.DECLINE_ACCESS_CONDITIONS.name())
-        .target(NegotiationResourceState.RESOURCE_NOT_MADE_AVAILABLE.name())
-        .secured("isCreator", SecurityRule.ComparisonType.ALL)
-        .and()
-        .withExternal()
-        .source(NegotiationResourceState.ACCESS_CONDITIONS_INDICATED.name())
-        .event(NegotiationResourceEvent.ACCEPT_ACCESS_CONDITIONS.name())
-        .target(NegotiationResourceState.ACCESS_CONDITIONS_MET.name())
-        .secured("isCreator", SecurityRule.ComparisonType.ALL)
-        .and()
-        .withExternal()
-        .source(NegotiationResourceState.ACCESS_CONDITIONS_MET.name())
-        .event(NegotiationResourceEvent.GRANT_ACCESS_TO_RESOURCE.name())
-        .target(NegotiationResourceState.RESOURCE_MADE_AVAILABLE.name())
         .secured("isRepresentative", SecurityRule.ComparisonType.ALL);
 
     transitions.withExternal().guard(negotiationIsApproved());


### PR DESCRIPTION
### Description:

Introduces a new Spring profile `minimal-workflow` that activates a simplified version of the resource state machine. Under this profile, representatives can grant access directly from REPRESENTATIVE_CONTACTED without going through the availability-checking and access-condition steps.

The original ResourceStateMachineConfig is unchanged except for a `@Profile("!minimal-workflow")` guard. A new `SimplifiedResourceStateMachineConfig` registers the same "resourceStateMachine" bean with only 5 transitions: SUBMITTED → REPRESENTATIVE_CONTACTED/UNREACHABLE (admin), then REPRESENTATIVE_CONTACTED → RESOURCE_MADE_AVAILABLE (GRANT_ACCESS_TO_RESOURCE) or RESOURCE_UNAVAILABLE (STEP_AWAY) by the representative.

All enums, DB schema, service layer, notifications, and tests are untouched. Activate with `SPRING_PROFILES_ACTIVE=prod,minimal-workflow`.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
