### PR TITLE
fix: added authorization for admins to remove resources from negotiation

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
@@ -386,9 +386,10 @@ public class NegotiationServiceImpl implements NegotiationService {
   }
 
   private void verifyRemoveResourcePreconditions(String negotiationId, Negotiation negotiation) {
-    if (!isNegotiationCreator(negotiationId)) {
+    if (!isNegotiationCreator(negotiationId)
+        && !AuthenticatedUserContext.isCurrentlyAuthenticatedUserAdmin()) {
       throw new ForbiddenRequestException(
-          "Only the negotiation author can remove resources from a draft negotiation");
+          "Only the negotiation author and admins can remove resources from a draft negotiation");
     }
     if (negotiation.getCurrentState() != NegotiationState.DRAFT) {
       throw new IllegalStateException(

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/negotiation/NegotiationControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/negotiation/NegotiationControllerTests.java
@@ -1636,9 +1636,58 @@ public class NegotiationControllerTests {
   }
 
   @Test
+  @WithUserDetails("admin")
+  @Transactional
+  void removeResource_draftStatus_multipleResources_adminCanRemoveResource() throws Exception {
+    // negotiation-5 belongs to TheResearcher and has 2 resources (ids 5 and 7)
+    Negotiation negotiation = negotiationRepository.findById(NEGOTIATION_5_ID).get();
+    negotiation.setCurrentState(NegotiationState.DRAFT);
+    negotiationRepository.saveAndFlush(negotiation);
+
+    int initialResourceCount = negotiation.getResources().size();
+    Assertions.assertTrue(initialResourceCount > 1, "Negotiation should have more than 1 resource");
+
+    Long resourceIdToRemove = negotiation.getResources().iterator().next().getId();
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.delete(
+                "%s/%s/resources/%s"
+                    .formatted(NEGOTIATIONS_URL, NEGOTIATION_5_ID, resourceIdToRemove)))
+        .andExpect(status().isNoContent());
+
+    Negotiation updatedNegotiation = negotiationRepository.findById(NEGOTIATION_5_ID).get();
+    assertEquals(
+        initialResourceCount - 1,
+        updatedNegotiation.getResources().size(),
+        "Resource should be removed from the negotiation");
+  }
+
+  @Test
   @WithUserDetails("TheResearcher")
   @Transactional
   void removeResource_draftStatus_onlyOneResourceLeft_throwsBadRequest() throws Exception {
+    Negotiation negotiation = negotiationRepository.findById(NEGOTIATION_5_ID).get();
+    negotiation.setCurrentState(NegotiationState.DRAFT);
+    negotiationRepository.saveAndFlush(negotiation);
+    Long resourceIdToRemove = negotiation.getResources().iterator().next().getId();
+    mockMvc.perform(
+        MockMvcRequestBuilders.delete(
+            "%s/%s/resources/%s"
+                .formatted(NEGOTIATIONS_URL, NEGOTIATION_5_ID, resourceIdToRemove)));
+    resourceIdToRemove = negotiation.getResources().iterator().next().getId();
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.delete(
+                "%s/%s/resources/%s"
+                    .formatted(NEGOTIATIONS_URL, NEGOTIATION_5_ID, resourceIdToRemove)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithUserDetails("admin")
+  @Transactional
+  void removeResource_draftStatus_onlyOneResourceLeft_asAdmin_throwsBadRequest() throws Exception {
     Negotiation negotiation = negotiationRepository.findById(NEGOTIATION_5_ID).get();
     negotiation.setCurrentState(NegotiationState.DRAFT);
     negotiationRepository.saveAndFlush(negotiation);


### PR DESCRIPTION
### Description:

Admins now have the proper authorization to remove resources from a negotiation which they do not own. 

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
