### PR TITLE
fix: slow responsiveness for large negotiations

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationDTO.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationDTO.java
@@ -2,34 +2,17 @@ package eu.bbmri_eric.negotiator.governance.organization;
 
 import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Objects;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+
+import lombok.*;
 import org.springframework.hateoas.server.core.Relation;
 
-@Getter
-@Setter
+@Data
+@EqualsAndHashCode(callSuper = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Relation(collectionRelation = "organizations", itemRelation = "organization")
 @Schema(description = "An organization")
 public class OrganizationForNegotiationDTO extends OrganizationDTO {
   boolean updatable;
-
   NegotiationResourceState status;
-
-  @Override
-  public boolean equals(Object o) {
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-    OrganizationForNegotiationDTO that = (OrganizationForNegotiationDTO) o;
-    return updatable == that.updatable && status == that.status;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), updatable, status);
-  }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationDTO.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationDTO.java
@@ -2,7 +2,6 @@ package eu.bbmri_eric.negotiator.governance.organization;
 
 import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.*;
 import org.springframework.hateoas.server.core.Relation;
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationDTO.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationDTO.java
@@ -1,0 +1,36 @@
+package eu.bbmri_eric.negotiator.governance.organization;
+
+import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.hateoas.server.core.Relation;
+
+import java.util.Objects;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Relation(collectionRelation = "organizations", itemRelation = "organization")
+@Schema(description = "An organization")
+public class OrganizationForNegotiationDTO extends OrganizationDTO {
+    boolean updatable;
+
+    NegotiationResourceState status;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        OrganizationForNegotiationDTO that = (OrganizationForNegotiationDTO) o;
+        return updatable == that.updatable && status == that.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), updatable, status);
+    }
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationDTO.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationDTO.java
@@ -2,13 +2,12 @@ package eu.bbmri_eric.negotiator.governance.organization;
 
 import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.hateoas.server.core.Relation;
-
-import java.util.Objects;
 
 @Getter
 @Setter
@@ -17,20 +16,20 @@ import java.util.Objects;
 @Relation(collectionRelation = "organizations", itemRelation = "organization")
 @Schema(description = "An organization")
 public class OrganizationForNegotiationDTO extends OrganizationDTO {
-    boolean updatable;
+  boolean updatable;
 
-    NegotiationResourceState status;
+  NegotiationResourceState status;
 
-    @Override
-    public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        OrganizationForNegotiationDTO that = (OrganizationForNegotiationDTO) o;
-        return updatable == that.updatable && status == that.status;
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    OrganizationForNegotiationDTO that = (OrganizationForNegotiationDTO) o;
+    return updatable == that.updatable && status == that.status;
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), updatable, status);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), updatable, status);
+  }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationModelAssembler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationModelAssembler.java
@@ -5,14 +5,14 @@ import org.springframework.hateoas.server.RepresentationModelAssembler;
 import org.springframework.stereotype.Component;
 
 @Component
-public class OrganizationForNegotiationModelAssembler implements RepresentationModelAssembler<
-        OrganizationForNegotiationDTO,
-        EntityModel<OrganizationForNegotiationDTO>> {
+public class OrganizationForNegotiationModelAssembler
+    implements RepresentationModelAssembler<
+        OrganizationForNegotiationDTO, EntityModel<OrganizationForNegotiationDTO>> {
 
-    @Override
-    public EntityModel<OrganizationForNegotiationDTO> toModel(
-            OrganizationForNegotiationDTO organization) {
+  @Override
+  public EntityModel<OrganizationForNegotiationDTO> toModel(
+      OrganizationForNegotiationDTO organization) {
 
-        return EntityModel.of(organization);
-    }
+    return EntityModel.of(organization);
+  }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationModelAssembler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationForNegotiationModelAssembler.java
@@ -1,0 +1,18 @@
+package eu.bbmri_eric.negotiator.governance.organization;
+
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrganizationForNegotiationModelAssembler implements RepresentationModelAssembler<
+        OrganizationForNegotiationDTO,
+        EntityModel<OrganizationForNegotiationDTO>> {
+
+    @Override
+    public EntityModel<OrganizationForNegotiationDTO> toModel(
+            OrganizationForNegotiationDTO organization) {
+
+        return EntityModel.of(organization);
+    }
+}

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationRepository.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationRepository.java
@@ -61,7 +61,6 @@ public interface OrganizationRepository
                       END DESC
                   LIMIT 1;
                   """,
-          nativeQuery = true)
+      nativeQuery = true)
   NegotiationResourceState getCurrentOrganizationState(Long organizationId, String negotiationId);
-
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationRepository.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/organization/OrganizationRepository.java
@@ -1,5 +1,6 @@
 package eu.bbmri_eric.negotiator.governance.organization;
 
+import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
 import jakarta.validation.constraints.NotNull;
 import java.util.Optional;
 import java.util.Set;
@@ -34,4 +35,33 @@ public interface OrganizationRepository
       nativeQuery = true)
   Set<Organization> findAllOrganizationsContainingResourceRepresentedByUser(
       Long personId, String name, Boolean withdrawn);
+
+  @Query(
+      value =
+          """
+                  SELECT nrl.current_state
+                  FROM negotiation_resource_link nrl
+                      INNER JOIN resource r ON nrl.resource_id = r.id
+                  WHERE r.organization_id = :organizationId
+                      AND nrl.negotiation_id = :negotiationId
+                  ORDER BY
+                      CASE nrl.current_state
+                          WHEN 'SUBMITTED' THEN 0
+                          WHEN 'REPRESENTATIVE_UNREACHABLE' THEN 1
+                          WHEN 'REPRESENTATIVE_CONTACTED' THEN 2
+                          WHEN 'RETURNED_FOR_RESUBMISSION' THEN 3
+                          WHEN 'CHECKING_AVAILABILITY' THEN 4
+                          WHEN 'RESOURCE_UNAVAILABLE_WILLING_TO_COLLECT' THEN 5
+                          WHEN 'RESOURCE_UNAVAILABLE' THEN 6
+                          WHEN 'RESOURCE_AVAILABLE' THEN 7
+                          WHEN 'ACCESS_CONDITIONS_INDICATED' THEN 8
+                          WHEN 'ACCESS_CONDITIONS_MET' THEN 9
+                          WHEN 'RESOURCE_NOT_MADE_AVAILABLE' THEN 10
+                          WHEN 'RESOURCE_MADE_AVAILABLE' THEN 11
+                      END DESC
+                  LIMIT 1;
+                  """,
+          nativeQuery = true)
+  NegotiationResourceState getCurrentOrganizationState(Long organizationId, String negotiationId);
+
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceRepository.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceRepository.java
@@ -65,10 +65,10 @@ order by rs.source_id;
             left join public.negotiation_resource_link nrl on rs.id = nrl.resource_id
             join public.organization o on o.id = rs.organization_id
         where
-            nrl.negotiation_id = :negotiationId
+            nrl.negotiation_id = :negotiationId and o.external_id = :organizationId
         """,
           nativeQuery = true)
-  Page<ResourceViewDTO> findByNegotiationPaginated(String negotiationId, Pageable pageable);
+  Page<ResourceViewDTO> findByNegotiationAndOrganizationPaginated(String negotiationId, String organizationId, Pageable pageable);
 
   Optional<Resource> findByName(String name);
 
@@ -90,4 +90,17 @@ order by rs.source_id;
           """,
       nativeQuery = true)
   Set<Resource> findByRepresentativeAndOrganization(Long representativeId, Long organizationId);
+
+  @Query(
+          value =
+                  """
+        select
+            COUNT(DISTINCT rs.id)
+        from resource rs
+            left join public.negotiation_resource_link nrl on rs.id = nrl.resource_id
+        where
+            nrl.negotiation_id = :negotiationId
+        """,
+          nativeQuery = true)
+  Integer countDistinctByNegotiation(String negotiationId);
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceRepository.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceRepository.java
@@ -43,6 +43,33 @@ order by rs.source_id;
       nativeQuery = true)
   List<ResourceViewDTO> findByNegotiation(String negotiationId);
 
+  @Query(
+          value =
+                  """
+        select
+            rs.id              as id,
+            nrl.negotiation_id as negotiationId,
+            rs.name            as name,
+            rs.source_id       as sourceId,
+            rs.contact_email   as contactEmail,
+            rs.description     as description,
+            rs.uri             as uri,
+            nrl.current_state as currentState,
+            o.name             as organizationName,
+            o.external_id      as organizationExternalId,
+            o.id               as organizationId,
+            o.contact_email    as organizationContactEmail,
+            o.description      as organizationDescription,
+            o.uri              as organizationUri
+        from resource rs
+            left join public.negotiation_resource_link nrl on rs.id = nrl.resource_id
+            join public.organization o on o.id = rs.organization_id
+        where
+            nrl.negotiation_id = :negotiationId
+        """,
+          nativeQuery = true)
+  Page<ResourceViewDTO> findByNegotiationPaginated(String negotiationId, Pageable pageable);
+
   Optional<Resource> findByName(String name);
 
   Optional<Resource> findBySourceId(String sourceId);

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceRepository.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceRepository.java
@@ -67,6 +67,15 @@ order by rs.source_id;
         where
             nrl.negotiation_id = :negotiationId and o.external_id = :organizationId
         """,
+      countQuery =
+          """
+        select count(*)
+        from resource rs
+            join public.negotiation_resource_link nrl on rs.id = nrl.resource_id
+            join public.organization o on o.id = rs.organization_id
+        where
+            nrl.negotiation_id = :negotiationId and o.external_id = :organizationId
+        """,
       nativeQuery = true)
   Page<ResourceViewDTO> findByNegotiationAndOrganizationPaginated(
       String negotiationId, String organizationId, Pageable pageable);

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceRepository.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceRepository.java
@@ -44,8 +44,8 @@ order by rs.source_id;
   List<ResourceViewDTO> findByNegotiation(String negotiationId);
 
   @Query(
-          value =
-                  """
+      value =
+          """
         select
             rs.id              as id,
             nrl.negotiation_id as negotiationId,
@@ -67,8 +67,9 @@ order by rs.source_id;
         where
             nrl.negotiation_id = :negotiationId and o.external_id = :organizationId
         """,
-          nativeQuery = true)
-  Page<ResourceViewDTO> findByNegotiationAndOrganizationPaginated(String negotiationId, String organizationId, Pageable pageable);
+      nativeQuery = true)
+  Page<ResourceViewDTO> findByNegotiationAndOrganizationPaginated(
+      String negotiationId, String organizationId, Pageable pageable);
 
   Optional<Resource> findByName(String name);
 
@@ -92,8 +93,8 @@ order by rs.source_id;
   Set<Resource> findByRepresentativeAndOrganization(Long representativeId, Long organizationId);
 
   @Query(
-          value =
-                  """
+      value =
+          """
         select
             COUNT(DISTINCT rs.id)
         from resource rs
@@ -101,6 +102,6 @@ order by rs.source_id;
         where
             nrl.negotiation_id = :negotiationId
         """,
-          nativeQuery = true)
+      nativeQuery = true)
   Integer countDistinctByNegotiation(String negotiationId);
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceService.java
@@ -8,7 +8,6 @@ import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceUpdateDTO;
 import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceWithStatusDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.UpdateResourcesDTO;
 import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -52,7 +51,8 @@ public interface ResourceService {
    * @param negotiationId the id of the Negotiation
    * @return a list of resources
    */
-  Page<ResourceWithStatusDTO> findPaginatedInNegotiationByOrganization(String negotiationId, String organizationId, Pageable pageable);
+  Page<ResourceWithStatusDTO> findPaginatedInNegotiationByOrganization(
+      String negotiationId, String organizationId, Pageable pageable);
 
   /**
    * Edit resources to a Negotiation. Any Resources in the list that are not already a part of the

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceService.java
@@ -7,6 +7,8 @@ import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceUpdateDTO;
 import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceWithStatusDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.UpdateResourcesDTO;
 import java.util.List;
+
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 /** The ResourceService interface defines the contract for accessing and manipulating resources. */
@@ -42,6 +44,14 @@ public interface ResourceService {
    * @return a list of resources
    */
   List<ResourceWithStatusDTO> findAllInNegotiation(String negotiationId);
+
+  /**
+   * Find paginated Resources involved in a specific Negotiation
+   *
+   * @param negotiationId the id of the Negotiation
+   * @return a list of resources
+   */
+  Page<ResourceWithStatusDTO> findPaginatedInNegotiation(String negotiationId, Pageable pageable);
 
   /**
    * Edit resources to a Negotiation. Any Resources in the list that are not already a part of the

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceService.java
@@ -61,10 +61,8 @@ public interface ResourceService {
    *
    * @param negotiationId a specific Negotiation
    * @param updateResourcesDTO a list of resource IDs to be added or updated
-   * @return an updated list of resources
    */
-  List<ResourceWithStatusDTO> updateResourcesInANegotiation(
-      String negotiationId, UpdateResourcesDTO updateResourcesDTO);
+  void updateResourcesInANegotiation(String negotiationId, UpdateResourcesDTO updateResourcesDTO);
 
   /**
    * Add a batch of resources. This method is uses from a specific synchronization servvice that

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceService.java
@@ -1,6 +1,7 @@
 package eu.bbmri_eric.negotiator.governance.resource;
 
 import eu.bbmri_eric.negotiator.common.FilterDTO;
+import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
 import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceCreateDTO;
 import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceResponseModel;
 import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceUpdateDTO;
@@ -51,7 +52,7 @@ public interface ResourceService {
    * @param negotiationId the id of the Negotiation
    * @return a list of resources
    */
-  Page<ResourceWithStatusDTO> findPaginatedInNegotiation(String negotiationId, Pageable pageable);
+  Page<ResourceWithStatusDTO> findPaginatedInNegotiationByOrganization(String negotiationId, String organizationId, Pageable pageable);
 
   /**
    * Edit resources to a Negotiation. Any Resources in the list that are not already a part of the
@@ -82,4 +83,14 @@ public interface ResourceService {
    * @return the output DTO of the updated resource
    */
   ResourceResponseModel updateResourceById(Long id, ResourceUpdateDTO resource);
+
+  /**
+   * Counts the number of resources linked to a negotiation.
+   *
+   * @param negotiationId the id of the negotiation
+   * @throws EntityNotFoundException if the negotiation is not found
+   * @throws eu.bbmri_eric.negotiator.common.exceptions.ForbiddenRequestException if the user is not
+   *     authorized
+   */
+  Integer countResourcesByNegotiationId(String negotiationId);
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceServiceImpl.java
@@ -154,7 +154,8 @@ public class ResourceServiceImpl implements ResourceService {
   }
 
   @Override
-  public Page<ResourceWithStatusDTO> findPaginatedInNegotiationByOrganization(String negotiationId, String organizationId, Pageable pageable) {
+  public Page<ResourceWithStatusDTO> findPaginatedInNegotiationByOrganization(
+      String negotiationId, String organizationId, Pageable pageable) {
     if (!negotiationRepository.existsById(negotiationId)) {
       throw new EntityNotFoundException(negotiationId);
     }
@@ -163,9 +164,11 @@ public class ResourceServiceImpl implements ResourceService {
     }
     Long userId = AuthenticatedUserContext.getCurrentlyAuthenticatedUserInternalId();
     negotiationAccessManager.verifyReadAccessForNegotiation(negotiationId, userId);
-    Page<ResourceViewDTO> resourceViewDTOS = repository.findByNegotiationAndOrganizationPaginated(negotiationId, organizationId, pageable);
-    return resourceViewDTOS
-            .map(resourceViewDTO -> modelMapper.map(resourceViewDTO, ResourceWithStatusDTO.class));
+    Page<ResourceViewDTO> resourceViewDTOS =
+        repository.findByNegotiationAndOrganizationPaginated(
+            negotiationId, organizationId, pageable);
+    return resourceViewDTOS.map(
+        resourceViewDTO -> modelMapper.map(resourceViewDTO, ResourceWithStatusDTO.class));
   }
 
   @Override

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceServiceImpl.java
@@ -39,6 +39,7 @@ import lombok.NonNull;
 import lombok.extern.apachecommons.CommonsLog;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -150,6 +151,19 @@ public class ResourceServiceImpl implements ResourceService {
     return resourceViewDTOS.stream()
         .map(resourceViewDTO -> modelMapper.map(resourceViewDTO, ResourceWithStatusDTO.class))
         .toList();
+  }
+
+  @Override
+  @Transactional
+  public Page<ResourceWithStatusDTO> findPaginatedInNegotiation(String negotiationId, Pageable pageable) {
+    if (!negotiationRepository.existsById(negotiationId)) {
+      throw new EntityNotFoundException(negotiationId);
+    }
+    Long userId = AuthenticatedUserContext.getCurrentlyAuthenticatedUserInternalId();
+    negotiationAccessManager.verifyReadAccessForNegotiation(negotiationId, userId);
+    Page<ResourceViewDTO> resourceViewDTOS = repository.findByNegotiationPaginated(negotiationId, pageable);
+    return resourceViewDTOS
+            .map(resourceViewDTO -> modelMapper.map(resourceViewDTO, ResourceWithStatusDTO.class));
   }
 
   @Override

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceServiceImpl.java
@@ -36,7 +36,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.NonNull;
-import lombok.extern.apachecommons.CommonsLog;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -46,7 +45,6 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 @Service
-@CommonsLog
 public class ResourceServiceImpl implements ResourceService {
 
   private final NetworkRepository networkRepository;
@@ -173,7 +171,7 @@ public class ResourceServiceImpl implements ResourceService {
 
   @Override
   @Transactional
-  public List<ResourceWithStatusDTO> updateResourcesInANegotiation(
+  public void updateResourcesInANegotiation(
       String negotiationId, UpdateResourcesDTO updateResourcesDTO) {
     Negotiation negotiation = fetchNegotiationFromDB(negotiationId);
     Set<Resource> resourcesToUpdate = fetchResourcesFromDB(updateResourcesDTO.getResourceIds());
@@ -185,7 +183,6 @@ public class ResourceServiceImpl implements ResourceService {
     if (negotiation.getCurrentState().equals(NegotiationState.IN_PROGRESS)) {
       applicationEventPublisher.publishEvent(new NewResourcesAddedEvent(this, negotiation.getId()));
     }
-    return getResourceWithStatusDTOS(negotiationId);
   }
 
   private void setStatusForUpdatedResources(
@@ -267,16 +264,6 @@ public class ResourceServiceImpl implements ResourceService {
     List<Resource> savedResources = repository.saveAll(resources);
     return savedResources.stream()
         .map(resource -> modelMapper.map(resource, ResourceResponseModel.class))
-        .toList();
-  }
-
-  private @NonNull List<ResourceWithStatusDTO> getResourceWithStatusDTOS(String negotiationId) {
-    List<ResourceViewDTO> resourceViewDTOS = repository.findByNegotiation(negotiationId);
-    log.debug(
-        "Negotiation %s now has %s resources after modification"
-            .formatted(negotiationId, resourceViewDTOS.size()));
-    return resourceViewDTOS.stream()
-        .map(resourceViewDTO -> modelMapper.map(resourceViewDTO, ResourceWithStatusDTO.class))
         .toList();
   }
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/governance/resource/ResourceServiceImpl.java
@@ -154,14 +154,16 @@ public class ResourceServiceImpl implements ResourceService {
   }
 
   @Override
-  @Transactional
-  public Page<ResourceWithStatusDTO> findPaginatedInNegotiation(String negotiationId, Pageable pageable) {
+  public Page<ResourceWithStatusDTO> findPaginatedInNegotiationByOrganization(String negotiationId, String organizationId, Pageable pageable) {
     if (!negotiationRepository.existsById(negotiationId)) {
       throw new EntityNotFoundException(negotiationId);
     }
+    if (!organizationRepository.existsByExternalId(organizationId)) {
+      throw new EntityNotFoundException(organizationId);
+    }
     Long userId = AuthenticatedUserContext.getCurrentlyAuthenticatedUserInternalId();
     negotiationAccessManager.verifyReadAccessForNegotiation(negotiationId, userId);
-    Page<ResourceViewDTO> resourceViewDTOS = repository.findByNegotiationPaginated(negotiationId, pageable);
+    Page<ResourceViewDTO> resourceViewDTOS = repository.findByNegotiationAndOrganizationPaginated(negotiationId, organizationId, pageable);
     return resourceViewDTOS
             .map(resourceViewDTO -> modelMapper.map(resourceViewDTO, ResourceWithStatusDTO.class));
   }
@@ -226,6 +228,16 @@ public class ResourceServiceImpl implements ResourceService {
     modelMapper.map(updateDTO, resource);
     resource = repository.saveAndFlush(resource);
     return modelMapper.map(resource, ResourceWithOrgDTO.class);
+  }
+
+  @Override
+  public Integer countResourcesByNegotiationId(String negotiationId) {
+    if (!negotiationRepository.existsById(negotiationId)) {
+      throw new EntityNotFoundException(negotiationId);
+    }
+    Long userID = AuthenticatedUserContext.getCurrentlyAuthenticatedUserInternalId();
+    negotiationAccessManager.verifyReadAccessForNegotiation(negotiationId, userID);
+    return repository.countDistinctByNegotiation(negotiationId);
   }
 
   @Override

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
@@ -349,10 +349,10 @@ public class NegotiationController {
   @PatchMapping(value = "/negotiations/{id}/resources")
   @Operation(summary = "Edit Resources linked to a Negotiation")
   @SecurityRequirement(name = "security_auth")
-  public CollectionModel<EntityModel<ResourceWithStatusDTO>> updateResources(
+  public ResponseEntity<Void> updateResources(
       @PathVariable String id, @RequestBody @Valid UpdateResourcesDTO updateResourcesDTO) {
-    return resourceWithStatusAssembler.toCollectionModel(
-        resourceService.updateResourcesInANegotiation(id, updateResourcesDTO));
+    resourceService.updateResourcesInANegotiation(id, updateResourcesDTO);
+    return ResponseEntity.noContent().build();
   }
 
   @DeleteMapping(value = "/negotiations/{id}/resources/{resourceId}")

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
@@ -30,6 +30,11 @@ import java.util.stream.Collectors;
 import lombok.extern.apachecommons.CommonsLog;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
@@ -49,6 +54,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping("/v3")
@@ -282,7 +290,7 @@ public class NegotiationController {
         .collect(Collectors.toList());
   }
 
-  @GetMapping(value = "/negotiations/{id}/resources")
+  @GetMapping(value = "/negotiations/{id}/resources", params = "!page")
   @Operation(summary = "List all Resources in negotiation")
   @SecurityRequirement(name = "security_auth")
   public CollectionModel<EntityModel<ResourceWithStatusDTO>> findResourcesForNegotiation(
@@ -292,6 +300,29 @@ public class NegotiationController {
           resourceService.findAllInNegotiation(id), id);
     }
     return resourceWithStatusAssembler.toCollectionModel(resourceService.findAllInNegotiation(id));
+  }
+
+  @GetMapping(value = "/negotiations/{id}/resources", params = "page")
+  @Operation(summary = "List a page of Resources in negotiation")
+  @SecurityRequirement(name = "security_auth")
+  public PagedModel<EntityModel<ResourceWithStatusDTO>> findResourcesForNegotiationPaginated(
+          @PathVariable String id,
+          @PageableDefault(page = 1, size = 20, sort = "id", direction = Sort.Direction.ASC) Pageable pageable,
+          PagedResourcesAssembler<ResourceWithStatusDTO> pagedAssembler) {
+
+    Page<ResourceWithStatusDTO> page = resourceService.findPaginatedInNegotiation(id, pageable);
+
+    PagedModel<EntityModel<ResourceWithStatusDTO>> pagedModel =
+            pagedAssembler.toModel(page, resourceWithStatusAssembler);
+
+    if (AuthenticatedUserContext.isCurrentlyAuthenticatedUserAdmin()) {
+      pagedModel.add(
+              linkTo(methodOn(NegotiationController.class).updateResources(id, null))
+                      .withRel("add_resources")
+      );
+    }
+
+    return pagedModel;
   }
 
   @PatchMapping(value = "/negotiations/{id}/resources")

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
@@ -1,10 +1,11 @@
 package eu.bbmri_eric.negotiator.negotiation;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
 import eu.bbmri_eric.negotiator.common.AuthenticatedUserContext;
-import eu.bbmri_eric.negotiator.governance.organization.OrganizationDTO;
 import eu.bbmri_eric.negotiator.governance.organization.OrganizationForNegotiationDTO;
 import eu.bbmri_eric.negotiator.governance.organization.OrganizationForNegotiationModelAssembler;
-import eu.bbmri_eric.negotiator.governance.organization.OrganizationModelAssembler;
 import eu.bbmri_eric.negotiator.governance.resource.ResourceService;
 import eu.bbmri_eric.negotiator.governance.resource.ResourceWithStatusAssembler;
 import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceWithStatusDTO;
@@ -34,7 +35,6 @@ import java.util.stream.Collectors;
 import lombok.extern.apachecommons.CommonsLog;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -58,9 +58,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping("/v3")
@@ -312,9 +309,8 @@ public class NegotiationController {
 
     if (AuthenticatedUserContext.isCurrentlyAuthenticatedUserAdmin()) {
       entityModel.add(
-              linkTo(methodOn(NegotiationController.class).updateResources(id, null))
-                      .withRel("add_resources")
-      );
+          linkTo(methodOn(NegotiationController.class).updateResources(id, null))
+              .withRel("add_resources"));
     }
 
     return entityModel;
@@ -332,16 +328,20 @@ public class NegotiationController {
     return resourceWithStatusAssembler.toCollectionModel(resourceService.findAllInNegotiation(id));
   }
 
-  @GetMapping(value = "/negotiations/{id}/resources", params = {"page", "organizationId"})
+  @GetMapping(
+      value = "/negotiations/{id}/resources",
+      params = {"page", "organizationId"})
   @Operation(summary = "List a page of Resources in negotiation for a specific organization")
   @SecurityRequirement(name = "security_auth")
   public PagedModel<EntityModel<ResourceWithStatusDTO>> findResourcesForNegotiationAndOrgPaginated(
-          @PathVariable String id,
-          @RequestParam String organizationId,
-          @PageableDefault(page = 0, size = 20, sort = "id", direction = Sort.Direction.ASC) Pageable pageable,
-          PagedResourcesAssembler<ResourceWithStatusDTO> pagedAssembler) {
+      @PathVariable String id,
+      @RequestParam String organizationId,
+      @PageableDefault(page = 0, size = 20, sort = "id", direction = Sort.Direction.ASC)
+          Pageable pageable,
+      PagedResourcesAssembler<ResourceWithStatusDTO> pagedAssembler) {
 
-    Page<ResourceWithStatusDTO> page = resourceService.findPaginatedInNegotiationByOrganization(id, organizationId, pageable);
+    Page<ResourceWithStatusDTO> page =
+        resourceService.findPaginatedInNegotiationByOrganization(id, organizationId, pageable);
 
     return pagedAssembler.toModel(page, resourceWithStatusAssembler);
   }
@@ -370,9 +370,10 @@ public class NegotiationController {
   @GetMapping(value = "/negotiations/{id}/organizations")
   @Operation(summary = "List all Organizations involved in a negotiation")
   @SecurityRequirement(name = "security_auth")
-  public CollectionModel<EntityModel<OrganizationForNegotiationDTO>> findOrganizationsForNegotiation(
-          @PathVariable String id) {
-    return organizationForNegotiationModelAssembler.toCollectionModel(negotiationService.findDistinctOrganizationsInNegotiation(id));
+  public CollectionModel<EntityModel<OrganizationForNegotiationDTO>>
+      findOrganizationsForNegotiation(@PathVariable String id) {
+    return organizationForNegotiationModelAssembler.toCollectionModel(
+        negotiationService.findDistinctOrganizationsInNegotiation(id));
   }
 
   @GetMapping(value = "/negotiations/{id}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
@@ -107,7 +107,7 @@ public class NegotiationController {
     this.negotiationPdfService = negotiationPdfService;
   }
 
-  public record CountResponse(int count) {}
+  public record ResourceCountResponse(int count) {}
 
   /** Create a negotiation */
   @PostMapping(
@@ -299,13 +299,13 @@ public class NegotiationController {
   @GetMapping(value = "/negotiations/{id}/resources/info")
   @Operation(summary = "Get the number of resources linked to a negotiation")
   @SecurityRequirement(name = "security_auth")
-  public EntityModel<CountResponse> getNumberOfResourcesInNegotiation(@PathVariable String id) {
+  public EntityModel<ResourceCountResponse> getNumberOfResourcesInNegotiation(
+      @PathVariable String id) {
 
     int numberOfResources = resourceService.countResourcesByNegotiationId(id);
 
-    CountResponse payload = new CountResponse(numberOfResources);
-
-    EntityModel<CountResponse> entityModel = EntityModel.of(payload);
+    EntityModel<ResourceCountResponse> entityModel =
+        EntityModel.of(new ResourceCountResponse(numberOfResources));
 
     if (AuthenticatedUserContext.isCurrentlyAuthenticatedUserAdmin()) {
       entityModel.add(

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationController.java
@@ -1,6 +1,10 @@
 package eu.bbmri_eric.negotiator.negotiation;
 
 import eu.bbmri_eric.negotiator.common.AuthenticatedUserContext;
+import eu.bbmri_eric.negotiator.governance.organization.OrganizationDTO;
+import eu.bbmri_eric.negotiator.governance.organization.OrganizationForNegotiationDTO;
+import eu.bbmri_eric.negotiator.governance.organization.OrganizationForNegotiationModelAssembler;
+import eu.bbmri_eric.negotiator.governance.organization.OrganizationModelAssembler;
 import eu.bbmri_eric.negotiator.governance.resource.ResourceService;
 import eu.bbmri_eric.negotiator.governance.resource.ResourceWithStatusAssembler;
 import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceWithStatusDTO;
@@ -79,6 +83,7 @@ public class NegotiationController {
 
   private final NegotiationModelAssembler assembler;
   private final ResourceWithStatusAssembler resourceWithStatusAssembler;
+  private final OrganizationForNegotiationModelAssembler organizationForNegotiationModelAssembler;
 
   private final NegotiationPdfService negotiationPdfService;
 
@@ -91,6 +96,7 @@ public class NegotiationController {
       NegotiationTimeline timelineService,
       NegotiationModelAssembler assembler,
       ResourceWithStatusAssembler resourceWithStatusAssembler,
+      OrganizationForNegotiationModelAssembler organizationForNegotiationModelAssembler,
       NegotiationPdfService negotiationPdfService) {
     this.negotiationService = negotiationService;
     this.negotiationLifecycleService = negotiationLifecycleService;
@@ -100,8 +106,11 @@ public class NegotiationController {
     this.timelineService = timelineService;
     this.assembler = assembler;
     this.resourceWithStatusAssembler = resourceWithStatusAssembler;
+    this.organizationForNegotiationModelAssembler = organizationForNegotiationModelAssembler;
     this.negotiationPdfService = negotiationPdfService;
   }
+
+  public record CountResponse(int count) {}
 
   /** Create a negotiation */
   @PostMapping(
@@ -290,6 +299,27 @@ public class NegotiationController {
         .collect(Collectors.toList());
   }
 
+  @GetMapping(value = "/negotiations/{id}/resources/info")
+  @Operation(summary = "Get the number of resources linked to a negotiation")
+  @SecurityRequirement(name = "security_auth")
+  public EntityModel<CountResponse> getNumberOfResourcesInNegotiation(@PathVariable String id) {
+
+    int numberOfResources = resourceService.countResourcesByNegotiationId(id);
+
+    CountResponse payload = new CountResponse(numberOfResources);
+
+    EntityModel<CountResponse> entityModel = EntityModel.of(payload);
+
+    if (AuthenticatedUserContext.isCurrentlyAuthenticatedUserAdmin()) {
+      entityModel.add(
+              linkTo(methodOn(NegotiationController.class).updateResources(id, null))
+                      .withRel("add_resources")
+      );
+    }
+
+    return entityModel;
+  }
+
   @GetMapping(value = "/negotiations/{id}/resources", params = "!page")
   @Operation(summary = "List all Resources in negotiation")
   @SecurityRequirement(name = "security_auth")
@@ -302,27 +332,18 @@ public class NegotiationController {
     return resourceWithStatusAssembler.toCollectionModel(resourceService.findAllInNegotiation(id));
   }
 
-  @GetMapping(value = "/negotiations/{id}/resources", params = "page")
-  @Operation(summary = "List a page of Resources in negotiation")
+  @GetMapping(value = "/negotiations/{id}/resources", params = {"page", "organizationId"})
+  @Operation(summary = "List a page of Resources in negotiation for a specific organization")
   @SecurityRequirement(name = "security_auth")
-  public PagedModel<EntityModel<ResourceWithStatusDTO>> findResourcesForNegotiationPaginated(
+  public PagedModel<EntityModel<ResourceWithStatusDTO>> findResourcesForNegotiationAndOrgPaginated(
           @PathVariable String id,
-          @PageableDefault(page = 1, size = 20, sort = "id", direction = Sort.Direction.ASC) Pageable pageable,
+          @RequestParam String organizationId,
+          @PageableDefault(page = 0, size = 20, sort = "id", direction = Sort.Direction.ASC) Pageable pageable,
           PagedResourcesAssembler<ResourceWithStatusDTO> pagedAssembler) {
 
-    Page<ResourceWithStatusDTO> page = resourceService.findPaginatedInNegotiation(id, pageable);
+    Page<ResourceWithStatusDTO> page = resourceService.findPaginatedInNegotiationByOrganization(id, organizationId, pageable);
 
-    PagedModel<EntityModel<ResourceWithStatusDTO>> pagedModel =
-            pagedAssembler.toModel(page, resourceWithStatusAssembler);
-
-    if (AuthenticatedUserContext.isCurrentlyAuthenticatedUserAdmin()) {
-      pagedModel.add(
-              linkTo(methodOn(NegotiationController.class).updateResources(id, null))
-                      .withRel("add_resources")
-      );
-    }
-
-    return pagedModel;
+    return pagedAssembler.toModel(page, resourceWithStatusAssembler);
   }
 
   @PatchMapping(value = "/negotiations/{id}/resources")
@@ -344,6 +365,14 @@ public class NegotiationController {
   @SecurityRequirement(name = "security_auth")
   public void removeResource(@Valid @PathVariable String id, @Valid @PathVariable Long resourceId) {
     negotiationService.removeResourceFromNegotiation(id, resourceId);
+  }
+
+  @GetMapping(value = "/negotiations/{id}/organizations")
+  @Operation(summary = "List all Organizations involved in a negotiation")
+  @SecurityRequirement(name = "security_auth")
+  public CollectionModel<EntityModel<OrganizationForNegotiationDTO>> findOrganizationsForNegotiation(
+          @PathVariable String id) {
+    return organizationForNegotiationModelAssembler.toCollectionModel(negotiationService.findDistinctOrganizationsInNegotiation(id));
   }
 
   @GetMapping(value = "/negotiations/{id}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationRepository.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationRepository.java
@@ -8,9 +8,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -83,11 +80,13 @@ public interface NegotiationRepository
   @Query(value = "SELECT n FROM Negotiation n WHERE FUNCTION('DATE', n.creationDate) = :targetDate")
   Set<Negotiation> findAllCreatedOn(LocalDateTime targetDate);
 
-  @Query(value =
+  @Query(
+      value =
           "SELECT DISTINCT rs.organization "
-                  + "FROM Negotiation n "
-                  + "JOIN n.resourcesLink rl "
-                  + "JOIN rl.id.resource rs "
-                  + "WHERE n.id = :negotiationId")
-  List<Organization> findAllOrganizationsLinkedToNegotiation(@Param("negotiationId") String negotiationId);
+              + "FROM Negotiation n "
+              + "JOIN n.resourcesLink rl "
+              + "JOIN rl.id.resource rs "
+              + "WHERE n.id = :negotiationId")
+  List<Organization> findAllOrganizationsLinkedToNegotiation(
+      @Param("negotiationId") String negotiationId);
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationRepository.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationRepository.java
@@ -1,5 +1,6 @@
 package eu.bbmri_eric.negotiator.negotiation;
 
+import eu.bbmri_eric.negotiator.governance.organization.Organization;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
 import java.time.LocalDate;
@@ -7,9 +8,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -77,4 +82,12 @@ public interface NegotiationRepository
 
   @Query(value = "SELECT n FROM Negotiation n WHERE FUNCTION('DATE', n.creationDate) = :targetDate")
   Set<Negotiation> findAllCreatedOn(LocalDateTime targetDate);
+
+  @Query(value =
+          "SELECT DISTINCT rs.organization "
+                  + "FROM Negotiation n "
+                  + "JOIN n.resourcesLink rl "
+                  + "JOIN rl.id.resource rs "
+                  + "WHERE n.id = :negotiationId")
+  List<Organization> findAllOrganizationsLinkedToNegotiation(@Param("negotiationId") String negotiationId);
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationService.java
@@ -2,12 +2,17 @@ package eu.bbmri_eric.negotiator.negotiation;
 
 import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
 import eu.bbmri_eric.negotiator.common.exceptions.EntityNotStorableException;
+import eu.bbmri_eric.negotiator.governance.organization.OrganizationDTO;
+import eu.bbmri_eric.negotiator.governance.organization.OrganizationForNegotiationDTO;
+import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceWithStatusDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationCreateDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationFilterDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationUpdateDTO;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
 import java.util.List;
+
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface NegotiationService {
@@ -176,4 +181,14 @@ public interface NegotiationService {
    *     is not in DRAFT state
    */
   void removeResourceFromNegotiation(String negotiationId, Long resourceId);
+
+  /**
+   * Get all organizations involved in a negotiation through the resources linked to the negotiation.
+   *
+   * @param negotiationId the id of the negotiation
+   * @throws EntityNotFoundException if the negotiation is not found
+   * @throws eu.bbmri_eric.negotiator.common.exceptions.ForbiddenRequestException if the user is not
+   *     authorized
+   */
+  List<OrganizationForNegotiationDTO> findDistinctOrganizationsInNegotiation(String negotiationId);
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationService.java
@@ -2,17 +2,13 @@ package eu.bbmri_eric.negotiator.negotiation;
 
 import eu.bbmri_eric.negotiator.common.exceptions.EntityNotFoundException;
 import eu.bbmri_eric.negotiator.common.exceptions.EntityNotStorableException;
-import eu.bbmri_eric.negotiator.governance.organization.OrganizationDTO;
 import eu.bbmri_eric.negotiator.governance.organization.OrganizationForNegotiationDTO;
-import eu.bbmri_eric.negotiator.governance.resource.dto.ResourceWithStatusDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationCreateDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationFilterDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationUpdateDTO;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
 import java.util.List;
-
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface NegotiationService {
@@ -183,7 +179,8 @@ public interface NegotiationService {
   void removeResourceFromNegotiation(String negotiationId, Long resourceId);
 
   /**
-   * Get all organizations involved in a negotiation through the resources linked to the negotiation.
+   * Get all organizations involved in a negotiation through the resources linked to the
+   * negotiation.
    *
    * @param negotiationId the id of the negotiation
    * @throws EntityNotFoundException if the negotiation is not found

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
@@ -11,6 +11,10 @@ import eu.bbmri_eric.negotiator.common.exceptions.ForbiddenRequestException;
 import eu.bbmri_eric.negotiator.common.exceptions.WrongRequestException;
 import eu.bbmri_eric.negotiator.governance.network.Network;
 import eu.bbmri_eric.negotiator.governance.network.NetworkRepository;
+import eu.bbmri_eric.negotiator.governance.organization.Organization;
+import eu.bbmri_eric.negotiator.governance.organization.OrganizationDTO;
+import eu.bbmri_eric.negotiator.governance.organization.OrganizationForNegotiationDTO;
+import eu.bbmri_eric.negotiator.governance.organization.OrganizationRepository;
 import eu.bbmri_eric.negotiator.governance.resource.Resource;
 import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationCreateDTO;
 import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationDTO;
@@ -19,6 +23,7 @@ import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationUpdateDTO;
 import eu.bbmri_eric.negotiator.negotiation.request.Request;
 import eu.bbmri_eric.negotiator.negotiation.request.RequestRepository;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
 import eu.bbmri_eric.negotiator.user.Person;
 import eu.bbmri_eric.negotiator.user.PersonRepository;
 import eu.bbmri_eric.negotiator.user.PersonService;
@@ -34,6 +39,7 @@ import org.hibernate.exception.DataException;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -51,6 +57,7 @@ public class NegotiationServiceImpl implements NegotiationService {
   private RequestRepository requestRepository;
   private AttachmentRepository attachmentRepository;
   private NetworkRepository networkRepository;
+  private OrganizationRepository organizationRepository;
   private ModelMapper modelMapper;
   private PersonService personService;
   private ApplicationEventPublisher eventPublisher;
@@ -63,6 +70,7 @@ public class NegotiationServiceImpl implements NegotiationService {
       RequestRepository requestRepository,
       AttachmentRepository attachmentRepository,
       NetworkRepository networkRepository,
+      OrganizationRepository organizationRepository,
       ModelMapper modelMapper,
       PersonService personService,
       ApplicationEventPublisher eventPublisher,
@@ -73,6 +81,7 @@ public class NegotiationServiceImpl implements NegotiationService {
     this.requestRepository = requestRepository;
     this.attachmentRepository = attachmentRepository;
     this.networkRepository = networkRepository;
+    this.organizationRepository = organizationRepository;
     this.modelMapper = modelMapper;
     this.personService = personService;
     this.eventPublisher = eventPublisher;
@@ -409,5 +418,26 @@ public class NegotiationServiceImpl implements NegotiationService {
                 new EntityNotFoundException(
                     "Resource with id %s not found in negotiation %s"
                         .formatted(resourceId, negotiationId)));
+  }
+
+  @Override
+  public List<OrganizationForNegotiationDTO> findDistinctOrganizationsInNegotiation(String negotiationId) {
+    findEntityById(negotiationId, false);
+
+    Long userID = AuthenticatedUserContext.getCurrentlyAuthenticatedUserInternalId();
+    negotiationAccessManager.verifyReadAccessForNegotiation(negotiationId, userID);
+
+    return negotiationRepository.findAllOrganizationsLinkedToNegotiation(negotiationId)
+            .stream()
+            .map(organization -> {
+              OrganizationForNegotiationDTO dto =
+                      modelMapper.map(organization, OrganizationForNegotiationDTO.class);
+
+              dto.setUpdatable(personRepository.isRepresentativeOfAnyResourceOfOrganization(userID, organization.getExternalId()));
+              dto.setStatus(organizationRepository.getCurrentOrganizationState(organization.getId(), negotiationId));
+
+              return dto;
+            })
+            .collect(Collectors.toList());
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
@@ -11,8 +11,6 @@ import eu.bbmri_eric.negotiator.common.exceptions.ForbiddenRequestException;
 import eu.bbmri_eric.negotiator.common.exceptions.WrongRequestException;
 import eu.bbmri_eric.negotiator.governance.network.Network;
 import eu.bbmri_eric.negotiator.governance.network.NetworkRepository;
-import eu.bbmri_eric.negotiator.governance.organization.Organization;
-import eu.bbmri_eric.negotiator.governance.organization.OrganizationDTO;
 import eu.bbmri_eric.negotiator.governance.organization.OrganizationForNegotiationDTO;
 import eu.bbmri_eric.negotiator.governance.organization.OrganizationRepository;
 import eu.bbmri_eric.negotiator.governance.resource.Resource;
@@ -23,7 +21,6 @@ import eu.bbmri_eric.negotiator.negotiation.dto.NegotiationUpdateDTO;
 import eu.bbmri_eric.negotiator.negotiation.request.Request;
 import eu.bbmri_eric.negotiator.negotiation.request.RequestRepository;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
-import eu.bbmri_eric.negotiator.negotiation.state_machine.resource.NegotiationResourceState;
 import eu.bbmri_eric.negotiator.user.Person;
 import eu.bbmri_eric.negotiator.user.PersonRepository;
 import eu.bbmri_eric.negotiator.user.PersonService;
@@ -39,7 +36,6 @@ import org.hibernate.exception.DataException;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -421,23 +417,28 @@ public class NegotiationServiceImpl implements NegotiationService {
   }
 
   @Override
-  public List<OrganizationForNegotiationDTO> findDistinctOrganizationsInNegotiation(String negotiationId) {
+  public List<OrganizationForNegotiationDTO> findDistinctOrganizationsInNegotiation(
+      String negotiationId) {
     findEntityById(negotiationId, false);
 
     Long userID = AuthenticatedUserContext.getCurrentlyAuthenticatedUserInternalId();
     negotiationAccessManager.verifyReadAccessForNegotiation(negotiationId, userID);
 
-    return negotiationRepository.findAllOrganizationsLinkedToNegotiation(negotiationId)
-            .stream()
-            .map(organization -> {
+    return negotiationRepository.findAllOrganizationsLinkedToNegotiation(negotiationId).stream()
+        .map(
+            organization -> {
               OrganizationForNegotiationDTO dto =
-                      modelMapper.map(organization, OrganizationForNegotiationDTO.class);
+                  modelMapper.map(organization, OrganizationForNegotiationDTO.class);
 
-              dto.setUpdatable(personRepository.isRepresentativeOfAnyResourceOfOrganization(userID, organization.getExternalId()));
-              dto.setStatus(organizationRepository.getCurrentOrganizationState(organization.getId(), negotiationId));
+              dto.setUpdatable(
+                  personRepository.isRepresentativeOfAnyResourceOfOrganization(
+                      userID, organization.getExternalId()));
+              dto.setStatus(
+                  organizationRepository.getCurrentOrganizationState(
+                      organization.getId(), negotiationId));
 
               return dto;
             })
-            .collect(Collectors.toList());
+        .collect(Collectors.toList());
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/NegotiationServiceImpl.java
@@ -439,6 +439,6 @@ public class NegotiationServiceImpl implements NegotiationService {
 
               return dto;
             })
-        .collect(Collectors.toList());
+        .toList();
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/governance/resource/ResourceControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/governance/resource/ResourceControllerTests.java
@@ -848,4 +848,69 @@ public class ResourceControllerTests {
                 .content(requestBody))
         .andExpect(status().isForbidden());
   }
+
+  @Test
+  @WithMockNegotiatorUser(id = 109L, authorities = "ROLE_ADMIN")
+  void getPaginatedResourcesForNegotiationByOrganization_validInput_ok() throws Exception {
+    String negotiationId = "negotiation-1";
+
+    String organizationExternalId =
+        repository.findByNegotiation(negotiationId).get(0).getOrganizationExternalId();
+
+    int expectedTotal =
+        repository
+            .findByNegotiationAndOrganizationPaginated(
+                negotiationId,
+                organizationExternalId,
+                org.springframework.data.domain.PageRequest.of(0, 20))
+            .getNumberOfElements();
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/v3/negotiations/{id}/resources", negotiationId)
+                .param("page", "0")
+                .param("size", "20")
+                .param("organizationId", organizationExternalId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.page.totalElements", is(expectedTotal)))
+        .andExpect(
+            jsonPath(
+                "$._embedded.resources[0].organization.externalId", is(organizationExternalId)));
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 109L, authorities = "ROLE_ADMIN")
+  void getPaginatedResourcesForNegotiationByOrganization_unknownOrganization_404()
+      throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/v3/negotiations/{id}/resources", "negotiation-1")
+                .param("page", "0")
+                .param("size", "20")
+                .param("organizationId", "organization-does-not-exist"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 109L, authorities = "ROLE_ADMIN")
+  void getNumberOfResourcesInNegotiation_validNegotiation_ok() throws Exception {
+    String negotiationId = "negotiation-1";
+    int expectedCount = repository.countDistinctByNegotiation(negotiationId);
+
+    mockMvc
+        .perform(MockMvcRequestBuilders.get("/v3/negotiations/{id}/resources/info", negotiationId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.count", is(expectedCount)))
+        .andExpect(jsonPath("$._links.add_resources.href").exists());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 109L, authorities = "ROLE_ADMIN")
+  void getNumberOfResourcesInNegotiation_unknownNegotiation_404() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(
+                "/v3/negotiations/{id}/resources/info", "unknown-negotiation"))
+        .andExpect(status().isNotFound());
+  }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/negotiation/NegotiationControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/negotiation/NegotiationControllerTests.java
@@ -2025,4 +2025,85 @@ public class NegotiationControllerTests {
         .andExpect(content().contentType("application/hal+json"))
         .andExpect(jsonPath("$.page.totalElements").value(0));
   }
+
+  @Test
+  @WithMockNegotiatorUser(id = 109L, authorities = "ROLE_ADMIN")
+  void getNumberOfResourcesInNegotiation_validNegotiation_ok() throws Exception {
+    String negotiationId = NEGOTIATION_1_ID;
+    int expectedCount = resourceRepository.countDistinctByNegotiation(negotiationId);
+
+    mockMvc
+        .perform(MockMvcRequestBuilders.get("/v3/negotiations/{id}/resources/info", negotiationId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.count", is(expectedCount)))
+        .andExpect(jsonPath("$._links.add_resources.href").exists());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 109L, authorities = "ROLE_ADMIN")
+  void findResourcesForNegotiationAndOrgPaginated_validInput_ok() throws Exception {
+    String negotiationId = NEGOTIATION_1_ID;
+    String organizationExternalId =
+        resourceRepository.findByNegotiation(negotiationId).get(0).getOrganizationExternalId();
+
+    int expectedTotal =
+        resourceRepository
+            .findByNegotiationAndOrganizationPaginated(
+                negotiationId,
+                organizationExternalId,
+                org.springframework.data.domain.PageRequest.of(0, 20))
+            .getNumberOfElements();
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/v3/negotiations/{id}/resources", negotiationId)
+                .param("page", "0")
+                .param("size", "20")
+                .param("organizationId", organizationExternalId))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/hal+json"))
+        .andExpect(jsonPath("$.page.totalElements", is(expectedTotal)))
+        .andExpect(
+            jsonPath(
+                "$._embedded.resources[0].organization.externalId", is(organizationExternalId)));
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 109L, authorities = "ROLE_ADMIN")
+  void findResourcesForNegotiationAndOrgPaginated_unknownOrganization_404() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/v3/negotiations/{id}/resources", NEGOTIATION_1_ID)
+                .param("page", "0")
+                .param("size", "20")
+                .param("organizationId", "organization-does-not-exist"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 109L, authorities = "ROLE_ADMIN")
+  void findOrganizationsForNegotiation_validNegotiation_ok() throws Exception {
+    String negotiationId = NEGOTIATION_1_ID;
+    int expectedOrganizations =
+        negotiationRepository.findAllOrganizationsLinkedToNegotiation(negotiationId).size();
+
+    mockMvc
+        .perform(MockMvcRequestBuilders.get("/v3/negotiations/{id}/organizations", negotiationId))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/hal+json"))
+        .andExpect(jsonPath("$._embedded.organizations.length()", is(expectedOrganizations)))
+        .andExpect(jsonPath("$._embedded.organizations[0].externalId").exists())
+        .andExpect(jsonPath("$._embedded.organizations[0].updatable").exists())
+        .andExpect(jsonPath("$._embedded.organizations[0].status").exists());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 109L, authorities = "ROLE_ADMIN")
+  void findOrganizationsForNegotiation_unknownNegotiation_404() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(
+                "/v3/negotiations/{id}/organizations", "unknown-negotiation"))
+        .andExpect(status().isNotFound());
+  }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/negotiation/NegotiationControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/negotiation/NegotiationControllerTests.java
@@ -1430,8 +1430,12 @@ public class NegotiationControllerTests {
                         .writeValueAsString(
                             new UpdateResourcesDTO(
                                 resources.stream().map(Resource::getId).toList()))))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$._embedded.resources.length()", is(resources.size() + count)));
+        .andExpect(status().isNoContent());
+
+    entityManager.clear();
+    Negotiation updatedNegotiation =
+        negotiationRepository.findById(negotiation.getId()).orElseThrow();
+    assertEquals(resources.size() + count, updatedNegotiation.getResources().size());
   }
 
   @Test
@@ -1440,25 +1444,28 @@ public class NegotiationControllerTests {
   void addResources_correctPayload_resourcesAddedAndWithStatus() throws Exception {
     Negotiation negotiation = negotiationRepository.findById("negotiation-1").get();
     List<Resource> resources = resourceRepository.findAll();
-    MvcResult result =
-        mockMvc
-            .perform(
-                MockMvcRequestBuilders.patch(
-                        "%s/%s/resources".formatted(NEGOTIATIONS_URL, negotiation.getId()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(
-                        new ObjectMapper()
-                            .writeValueAsString(
-                                new UpdateResourcesDTO(
-                                    resources.stream().map(Resource::getId).toList()))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$._embedded.resources.length()", is(resources.size())))
-            .andReturn();
-    JsonNode response = new ObjectMapper().readTree(result.getResponse().getContentAsString());
-    JsonNode resourcesAsJson = response.get("_embedded").get("resources");
-    for (JsonNode resourceAsJson : resourcesAsJson) {
-      assertNotNull(resourceAsJson.get("currentState"));
-    }
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.patch(
+                    "%s/%s/resources".formatted(NEGOTIATIONS_URL, negotiation.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    new ObjectMapper()
+                        .writeValueAsString(
+                            new UpdateResourcesDTO(
+                                resources.stream().map(Resource::getId).toList()))))
+        .andExpect(status().isNoContent());
+
+    entityManager.clear();
+    Negotiation updatedNegotiation =
+        negotiationRepository.findById(negotiation.getId()).orElseThrow();
+    assertEquals(resources.size(), updatedNegotiation.getResources().size());
+    updatedNegotiation
+        .getResources()
+        .forEach(
+            resource ->
+                assertNotNull(
+                    updatedNegotiation.getCurrentStateForResource(resource.getSourceId())));
   }
 
   @Test
@@ -1466,33 +1473,30 @@ public class NegotiationControllerTests {
   @Transactional
   void addResources_resourcesAlreadyPresent_noChange() throws Exception {
     Negotiation negotiation = negotiationRepository.findAll().get(0);
+    Resource markedResource = negotiation.getResources().iterator().next();
     negotiation.setStateForResource(
-        negotiation.getResources().iterator().next().getSourceId(),
-        NegotiationResourceState.REPRESENTATIVE_UNREACHABLE);
-    MvcResult result =
-        mockMvc
-            .perform(
-                MockMvcRequestBuilders.patch(
-                        "%s/%s/resources".formatted(NEGOTIATIONS_URL, negotiation.getId()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(
-                        new ObjectMapper()
-                            .writeValueAsString(
-                                new UpdateResourcesDTO(
-                                    negotiation.getResources().stream()
-                                        .map(Resource::getId)
-                                        .toList()))))
-            .andExpect(status().isOk())
-            .andExpect(
-                jsonPath("$._embedded.resources.length()", is(negotiation.getResources().size())))
-            .andReturn();
-    JsonNode response = new ObjectMapper().readTree(result.getResponse().getContentAsString());
-    JsonNode resourcesAsJson = response.get("_embedded").get("resources");
-    for (JsonNode resourceAsJson : resourcesAsJson) {
-      assertEquals(
-          negotiation.getCurrentStateForResource(resourceAsJson.get("sourceId").asText()),
-          NegotiationResourceState.valueOf(resourceAsJson.get("currentState").asText()));
-    }
+        markedResource.getSourceId(), NegotiationResourceState.REPRESENTATIVE_UNREACHABLE);
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.patch(
+                    "%s/%s/resources".formatted(NEGOTIATIONS_URL, negotiation.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    new ObjectMapper()
+                        .writeValueAsString(
+                            new UpdateResourcesDTO(
+                                negotiation.getResources().stream()
+                                    .map(Resource::getId)
+                                    .toList()))))
+        .andExpect(status().isNoContent());
+
+    entityManager.clear();
+    Negotiation updatedNegotiation =
+        negotiationRepository.findById(negotiation.getId()).orElseThrow();
+    assertEquals(negotiation.getResources().size(), updatedNegotiation.getResources().size());
+    assertEquals(
+        NegotiationResourceState.REPRESENTATIVE_UNREACHABLE,
+        updatedNegotiation.getCurrentStateForResource(markedResource.getSourceId()));
   }
 
   @Test
@@ -1503,24 +1507,24 @@ public class NegotiationControllerTests {
     NegotiationResourceState expectedState = NegotiationResourceState.RESOURCE_MADE_AVAILABLE;
     List<Long> resourceIds = negotiation.getResources().stream().map(Resource::getId).toList();
     UpdateResourcesDTO updateResourcesDTO = new UpdateResourcesDTO(resourceIds, expectedState);
-    MvcResult result =
-        mockMvc
-            .perform(
-                MockMvcRequestBuilders.patch(
-                        "%s/%s/resources".formatted(NEGOTIATIONS_URL, negotiation.getId()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(new ObjectMapper().writeValueAsString(updateResourcesDTO)))
-            .andExpect(status().isOk())
-            .andExpect(
-                jsonPath("$._embedded.resources.length()", is(negotiation.getResources().size())))
-            .andReturn();
-    JsonNode response = new ObjectMapper().readTree(result.getResponse().getContentAsString());
-    JsonNode resourcesAsJson = response.get("_embedded").get("resources");
-    for (JsonNode resourceAsJson : resourcesAsJson) {
-      assertEquals(
-          expectedState,
-          NegotiationResourceState.valueOf(resourceAsJson.get("currentState").asText()));
-    }
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.patch(
+                    "%s/%s/resources".formatted(NEGOTIATIONS_URL, negotiation.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(updateResourcesDTO)))
+        .andExpect(status().isNoContent());
+
+    entityManager.clear();
+    Negotiation updatedNegotiation =
+        negotiationRepository.findById(negotiation.getId()).orElseThrow();
+    updatedNegotiation
+        .getResources()
+        .forEach(
+            resource ->
+                assertEquals(
+                    expectedState,
+                    updatedNegotiation.getCurrentStateForResource(resource.getSourceId())));
   }
 
   @Test
@@ -1594,10 +1598,8 @@ public class NegotiationControllerTests {
                     "%s/%s/resources".formatted(NEGOTIATIONS_URL, negotiation.getId()))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(new ObjectMapper().writeValueAsString(updateResourcesDTO)))
-        .andExpect(status().isOk())
-        .andExpect(
-            jsonPath(
-                "$._embedded.resources.length()", is(initialResourceCount + newResources.size())));
+        .andExpect(status().isNoContent())
+        .andExpect(content().string(""));
 
     // Verify the resources were actually added
     Negotiation updatedNegotiation = negotiationRepository.findById(NEGOTIATION_1_ID).get();

--- a/frontend/cypress/e2e/Negotiation/sendMessage.cy.js
+++ b/frontend/cypress/e2e/Negotiation/sendMessage.cy.js
@@ -11,7 +11,7 @@ describe("Test negotiation message", () => {
     context("check if message part in negotiation is visible", () => {
         it("test if all message part are visible", () => {
             // Comment section
-            cy.get("[resources=\"[object Object]\"] > :nth-child(1)").should("be.visible")
+            cy.get('[data-cy="negotiation-posts"]').should('be.visible')
             // Send message section
             cy.get(".mb-4 > .mb-3").should("be.visible")
             cy.get("#recipient").should("be.visible")
@@ -23,7 +23,7 @@ describe("Test negotiation message", () => {
     context("check if you can send message in negotiation", () => {
         it("test send a message", () => {
             // Comment section
-            cy.get("[resources=\"[object Object]\"] > :nth-child(1)").should("be.visible")
+            cy.get('[data-cy="negotiation-posts"]').should('be.visible')
             // Send message section
             cy.get(".mb-4 > .mb-3").type("Hi i want to test message functionality, have a great day.")
             cy.get("#recipient").select("Public channel")
@@ -33,7 +33,7 @@ describe("Test negotiation message", () => {
     context("check if message is visible in negotiation", () => {
         it("test message visibility", () => {
             // Comment section
-            cy.get("[resources=\"[object Object]\"] > :nth-child(1)").should("be.visible")
+            cy.get('[data-cy="negotiation-posts"]').should('be.visible')
             // Display sender and reciver of message
             cy.get(".badge").should("be.visible")
         })

--- a/frontend/cypress/e2e/Negotiation/sendMessage.cy.js
+++ b/frontend/cypress/e2e/Negotiation/sendMessage.cy.js
@@ -11,7 +11,7 @@ describe("Test negotiation message", () => {
     context("check if message part in negotiation is visible", () => {
         it("test if all message part are visible", () => {
             // Comment section
-            cy.get('[data-cy="negotiation-posts"]').should('be.visible')
+            cy.get('[data-test="negotiation-posts"]').should('be.visible')
             // Send message section
             cy.get(".mb-4 > .mb-3").should("be.visible")
             cy.get("#recipient").should("be.visible")
@@ -23,7 +23,7 @@ describe("Test negotiation message", () => {
     context("check if you can send message in negotiation", () => {
         it("test send a message", () => {
             // Comment section
-            cy.get('[data-cy="negotiation-posts"]').should('be.visible')
+            cy.get('[data-test="negotiation-posts"]').should('be.visible')
             // Send message section
             cy.get(".mb-4 > .mb-3").type("Hi i want to test message functionality, have a great day.")
             cy.get("#recipient").select("Public channel")
@@ -33,7 +33,7 @@ describe("Test negotiation message", () => {
     context("check if message is visible in negotiation", () => {
         it("test message visibility", () => {
             // Comment section
-            cy.get('[data-cy="negotiation-posts"]').should('be.visible')
+            cy.get('[data-test="negotiation-posts"]').should('be.visible')
             // Display sender and reciver of message
             cy.get(".badge").should("be.visible")
         })

--- a/frontend/src/components/NegotiationSidebar.vue
+++ b/frontend/src/components/NegotiationSidebar.vue
@@ -114,7 +114,7 @@
           id="pdf-button"
           class="mt-2 v-step-negotiation-8"
           :negotiation-pdf-data="negotiation"
-          data-cy="pdf-button"
+          data-test="pdf-button"
           text="Download PDF"
           :include-attachments="false"
         />
@@ -122,7 +122,7 @@
           id="merged-pdf-button"
           class="mt-2"
           :negotiation-pdf-data="negotiation"
-          data-cy="merged-pdf-button"
+          data-test="merged-pdf-button"
           text="Download PDF with attachments"
           badge-text="Beta"
           badge-type="warning"

--- a/frontend/src/components/OrganizationCard.vue
+++ b/frontend/src/components/OrganizationCard.vue
@@ -1,4 +1,3 @@
-<script setup></script>
 <template>
   <div class="card mb-2">
     <OrganizationHeader

--- a/frontend/src/components/OrganizationCard.vue
+++ b/frontend/src/components/OrganizationCard.vue
@@ -10,7 +10,10 @@
       @toggle-collapse="toggleCollapse"
       @update-org-status="handleUpdateOrgStatus"
     />
-    <div :id="`card-body-block-${sanitizeId(orgId)}`" class="collapse multi-collapse">
+    <div
+      :id="`card-body-block-${sanitizeId(orgId)}`"
+      class="collapse multi-collapse"
+    >
       <ResourceItem
         v-for="resource in resources"
         :key="resource.id"
@@ -52,7 +55,7 @@
 </template>
 
 <script setup>
-import { computed, reactive, onBeforeMount, ref, watch } from 'vue'
+import { computed, onMounted, reactive, ref, watch } from 'vue'
 import OrganizationHeader from './OrganizationHeader.vue'
 import ResourceItem from './ResourceItem.vue'
 import { useNegotiationPageStore } from '../store/negotiationPage.js'
@@ -79,6 +82,9 @@ const resources = ref([])
 const isFetchingResources = ref(false)
 const pageInfo = ref({ number: 0, totalPages: 0, size: 20 })
 const negotiationPageStore = useNegotiationPageStore()
+const isExpanded = ref(false)
+const currentPage = ref(0)
+const resourcesCache = new Map()
 
 const dropdownVisible = reactive({})
 
@@ -93,6 +99,9 @@ const toggleDropdown = (orgId) => {
 }
 
 const toggleCollapse = (orgId) => {
+  const willExpand = !isExpanded.value
+  isExpanded.value = willExpand
+
   emit('toggle-collapse', orgId)
 }
 
@@ -120,25 +129,43 @@ function editInfoSubmission(href) {
   emit('edit-info-submission', href)
 }
 
-async function fetchResources(targetPage = 0) {
+async function fetchResources(targetPage = currentPage.value, { force = false } = {}) {
+  const pageToLoad = targetPage ?? currentPage.value
+
+  if (!force && resourcesCache.has(pageToLoad)) {
+    const cachedPage = resourcesCache.get(pageToLoad)
+    currentPage.value = pageToLoad
+    resources.value = cachedPage.resources
+    pageInfo.value = cachedPage.pageInfo
+    return cachedPage.response
+  }
+
   if (isFetchingResources.value) return
 
   isFetchingResources.value = true
+  currentPage.value = pageToLoad
 
   try {
     const response =
       await negotiationPageStore.retrieveResourcesByNegotiationIdAndOrganizationIdPaginated(
         props.negotiationId,
         props.orgId,
-        { page: targetPage, size: pageInfo.value.size || 20, sort: 'id' },
+        { page: pageToLoad, size: pageInfo.value.size || 20, sort: 'id' },
       )
 
     if (response !== undefined) {
-      resources.value = response?._embedded?.resources || []
+      const loadedResources = response?._embedded?.resources || []
+      const loadedPageInfo = response?.page ? { ...response.page } : { ...pageInfo.value }
 
-      if (response?.page) {
-        pageInfo.value = response.page
-      }
+      resources.value = loadedResources
+      pageInfo.value = loadedPageInfo
+      resourcesCache.set(pageToLoad, {
+        resources: loadedResources,
+        pageInfo: loadedPageInfo,
+        response,
+      })
+
+      return response
     }
   } finally {
     isFetchingResources.value = false
@@ -148,12 +175,16 @@ async function fetchResources(targetPage = 0) {
 watch(
   () => props.resourcesLastUpdated,
   () => {
-    fetchResources(pageInfo.value.number)
+    resourcesCache.clear()
+
+    if (isExpanded.value) {
+      void fetchResources(currentPage.value, { force: true })
+    }
   },
 )
 
-onBeforeMount(async () => {
-  await fetchResources(0)
+onMounted(() => {
+  void fetchResources(0)
 })
 
 defineExpose({

--- a/frontend/src/components/OrganizationCard.vue
+++ b/frontend/src/components/OrganizationCard.vue
@@ -22,6 +22,26 @@
         @update-resource-state="updateResourceState"
         @editInfoSubmission="editInfoSubmission"
       />
+
+      <div v-if="pageInfo && pageInfo.totalPages > 1" class="d-flex justify-content-between align-items-center p-2 border-top">
+        <button
+            class="btn btn-sm btn-outline-secondary"
+            :disabled="pageInfo.number === 0 || isLoading"
+            @click="$emit('change-page', pageInfo.number - 1)"
+        >
+          Previous
+        </button>
+        <span class="small text-muted">
+          Page {{ pageInfo.number + 1 }} of {{ pageInfo.totalPages }}
+        </span>
+        <button
+            class="btn btn-sm btn-outline-secondary"
+            :disabled="pageInfo.number >= pageInfo.totalPages - 1 || isLoading"
+            @click="$emit('change-page', pageInfo.number + 1)"
+        >
+          Next
+        </button>
+      </div>
     </div>
   </div>
 </template>
@@ -38,6 +58,8 @@ const props = defineProps({
   negotiationId: { type: String, default: undefined },
   uiConfiguration: { type: Object, required: true },
   isAdmin: { type: Boolean, default: false },
+  isLoading: { type: Boolean, default: false },
+  pageInfo: { type: Object, default: () => ({ number: 0, totalPages: 0 }) }
 })
 const emit = defineEmits([
   'open-form-modal',
@@ -45,6 +67,7 @@ const emit = defineEmits([
   'update-resource-state',
   'update-org-status',
   'edit-info-submission',
+  'change-page'
 ])
 
 const dropdownVisible = reactive({})

--- a/frontend/src/components/OrganizationCard.vue
+++ b/frontend/src/components/OrganizationCard.vue
@@ -1,3 +1,5 @@
+<script setup>
+</script>
 <template>
   <div class="card mb-2">
     <OrganizationHeader
@@ -12,7 +14,7 @@
     />
     <div :id="`card-body-block-${sanitizeId(orgId)}`" class="collapse multi-collapse">
       <ResourceItem
-        v-for="resource in org.resources"
+        v-for="resource in resources"
         :key="resource.id"
         :resource="resource"
         :ui-configuration="uiConfiguration"
@@ -26,8 +28,8 @@
       <div v-if="pageInfo && pageInfo.totalPages > 1" class="d-flex justify-content-between align-items-center p-2 border-top">
         <button
             class="btn btn-sm btn-outline-secondary"
-            :disabled="pageInfo.number === 0 || isLoading"
-            @click="$emit('change-page', pageInfo.number - 1)"
+            :disabled="pageInfo.number === 0 || isFetchingResources"
+            @click="fetchResources(pageInfo.number - 1)"
         >
           Previous
         </button>
@@ -36,8 +38,8 @@
         </span>
         <button
             class="btn btn-sm btn-outline-secondary"
-            :disabled="pageInfo.number >= pageInfo.totalPages - 1 || isLoading"
-            @click="$emit('change-page', pageInfo.number + 1)"
+            :disabled="pageInfo.number >= pageInfo.totalPages - 1 || isFetchingResources"
+            @click="fetchResources(pageInfo.number + 1)"
         >
           Next
         </button>
@@ -47,9 +49,10 @@
 </template>
 
 <script setup>
-import { computed, reactive } from 'vue'
+import { computed, reactive, onBeforeMount, ref, watch } from 'vue'
 import OrganizationHeader from './OrganizationHeader.vue'
 import ResourceItem from './ResourceItem.vue'
+import { useNegotiationPageStore } from '../store/negotiationPage.js'
 
 const props = defineProps({
   orgId: { type: String, default: undefined },
@@ -58,8 +61,7 @@ const props = defineProps({
   negotiationId: { type: String, default: undefined },
   uiConfiguration: { type: Object, required: true },
   isAdmin: { type: Boolean, default: false },
-  isLoading: { type: Boolean, default: false },
-  pageInfo: { type: Object, default: () => ({ number: 0, totalPages: 0 }) }
+  resourcesLastUpdated: { type: Number, default: 0 },
 })
 const emit = defineEmits([
   'open-form-modal',
@@ -67,8 +69,13 @@ const emit = defineEmits([
   'update-resource-state',
   'update-org-status',
   'edit-info-submission',
-  'change-page'
+  'toggle-collapse',
 ])
+
+const resources = ref([])
+const isFetchingResources = ref( false )
+const pageInfo = ref({ number: 0, totalPages: 0, size: 20 })
+const negotiationPageStore = useNegotiationPageStore()
 
 const dropdownVisible = reactive({})
 
@@ -109,6 +116,46 @@ const updateResourceState = (link) => {
 function editInfoSubmission(href) {
   emit('edit-info-submission', href)
 }
+
+async function fetchResources(targetPage = 0) {
+  if (isFetchingResources.value) return
+
+  isFetchingResources.value = true
+
+  try {
+    const response = await negotiationPageStore.retrieveResourcesByNegotiationIdAndOrganizationIdPaginated(
+        props.negotiationId,
+        props.orgId,
+        { page: targetPage, size: pageInfo.value.size || 20, sort: 'id' }
+    )
+
+    if (response !== undefined) {
+      resources.value = response?._embedded?.resources || []
+
+      if (response?.page) {
+        pageInfo.value = response.page
+      }
+    }
+  } finally {
+    isFetchingResources.value = false
+  }
+}
+
+watch(
+    () => props.resourcesLastUpdated,
+    () => {
+      fetchResources(pageInfo.value.number)
+    }
+)
+
+onBeforeMount(async () => {
+  await fetchResources(0)
+})
+
+defineExpose({
+  fetchResources,
+})
+
 </script>
 
 <style scoped>

--- a/frontend/src/components/OrganizationCard.vue
+++ b/frontend/src/components/OrganizationCard.vue
@@ -1,5 +1,4 @@
-<script setup>
-</script>
+<script setup></script>
 <template>
   <div class="card mb-2">
     <OrganizationHeader
@@ -25,11 +24,14 @@
         @editInfoSubmission="editInfoSubmission"
       />
 
-      <div v-if="pageInfo && pageInfo.totalPages > 1" class="d-flex justify-content-between align-items-center p-2 border-top">
+      <div
+        v-if="pageInfo && pageInfo.totalPages > 1"
+        class="d-flex justify-content-between align-items-center p-2 border-top"
+      >
         <button
-            class="btn btn-sm btn-outline-secondary"
-            :disabled="pageInfo.number === 0 || isFetchingResources"
-            @click="fetchResources(pageInfo.number - 1)"
+          class="btn btn-sm btn-outline-secondary"
+          :disabled="pageInfo.number === 0 || isFetchingResources"
+          @click="fetchResources(pageInfo.number - 1)"
         >
           Previous
         </button>
@@ -37,9 +39,9 @@
           Page {{ pageInfo.number + 1 }} of {{ pageInfo.totalPages }}
         </span>
         <button
-            class="btn btn-sm btn-outline-secondary"
-            :disabled="pageInfo.number >= pageInfo.totalPages - 1 || isFetchingResources"
-            @click="fetchResources(pageInfo.number + 1)"
+          class="btn btn-sm btn-outline-secondary"
+          :disabled="pageInfo.number >= pageInfo.totalPages - 1 || isFetchingResources"
+          @click="fetchResources(pageInfo.number + 1)"
         >
           Next
         </button>
@@ -73,7 +75,7 @@ const emit = defineEmits([
 ])
 
 const resources = ref([])
-const isFetchingResources = ref( false )
+const isFetchingResources = ref(false)
 const pageInfo = ref({ number: 0, totalPages: 0, size: 20 })
 const negotiationPageStore = useNegotiationPageStore()
 
@@ -123,11 +125,12 @@ async function fetchResources(targetPage = 0) {
   isFetchingResources.value = true
 
   try {
-    const response = await negotiationPageStore.retrieveResourcesByNegotiationIdAndOrganizationIdPaginated(
+    const response =
+      await negotiationPageStore.retrieveResourcesByNegotiationIdAndOrganizationIdPaginated(
         props.negotiationId,
         props.orgId,
-        { page: targetPage, size: pageInfo.value.size || 20, sort: 'id' }
-    )
+        { page: targetPage, size: pageInfo.value.size || 20, sort: 'id' },
+      )
 
     if (response !== undefined) {
       resources.value = response?._embedded?.resources || []
@@ -142,10 +145,10 @@ async function fetchResources(targetPage = 0) {
 }
 
 watch(
-    () => props.resourcesLastUpdated,
-    () => {
-      fetchResources(pageInfo.value.number)
-    }
+  () => props.resourcesLastUpdated,
+  () => {
+    fetchResources(pageInfo.value.number)
+  },
 )
 
 onBeforeMount(async () => {
@@ -155,7 +158,6 @@ onBeforeMount(async () => {
 defineExpose({
   fetchResources,
 })
-
 </script>
 
 <style scoped>

--- a/frontend/src/components/OrganizationCard.vue
+++ b/frontend/src/components/OrganizationCard.vue
@@ -189,6 +189,7 @@ onMounted(() => {
 
 defineExpose({
   fetchResources,
+  resources,
 })
 </script>
 

--- a/frontend/src/components/OrganizationCard.vue
+++ b/frontend/src/components/OrganizationCard.vue
@@ -29,6 +29,7 @@
         class="d-flex justify-content-between align-items-center p-2 border-top"
       >
         <button
+          type="button"
           class="btn btn-sm btn-outline-secondary"
           :disabled="pageInfo.number === 0 || isFetchingResources"
           @click="fetchResources(pageInfo.number - 1)"
@@ -39,6 +40,7 @@
           Page {{ pageInfo.number + 1 }} of {{ pageInfo.totalPages }}
         </span>
         <button
+          type="button"
           class="btn btn-sm btn-outline-secondary"
           :disabled="pageInfo.number >= pageInfo.totalPages - 1 || isFetchingResources"
           @click="fetchResources(pageInfo.number + 1)"

--- a/frontend/src/components/OrganizationContainer.vue
+++ b/frontend/src/components/OrganizationContainer.vue
@@ -37,11 +37,14 @@
     :negotiation-id="negotiationId"
     :ui-configuration="uiConfiguration"
     :isAdmin="isAdmin"
+    :is-loading="isLoading"
+    :page-info="pageInfo"
     @open-form-modal="openFormModal"
     @open-modal="openModal"
     @update-resource-state="updateResourceState"
     @update-org-status="updateOrgStatus"
     @editInfoSubmission="editInfoSubmission"
+    @change-page="(newPage) => $emit('change-page', newPage)"
   />
 </template>
 
@@ -62,8 +65,10 @@ const props = defineProps({
   resourceStates: { type: Array, default: () => [] },
   negotiationId: { type: String, default: undefined },
   isAdmin: { type: Boolean, default: false },
+  isLoading: { type: Boolean, default: false },
+  pageInfo: { type: Object, default: () => ({ number: 0, totalPages: 0 }) }
 })
-const emit = defineEmits(['reloadResources'])
+const emit = defineEmits(['reloadResources', 'change-page'])
 
 const uiConfigurationStore = useUiConfiguration()
 const negotiationPageStore = useNegotiationPageStore()

--- a/frontend/src/components/OrganizationContainer.vue
+++ b/frontend/src/components/OrganizationContainer.vue
@@ -31,20 +31,19 @@
 
   <!-- Organization Card Component -->
   <OrganizationCard
+    ref="organizationCardRef"
     :org-id="orgId"
     :org="org"
     :resource-states="resourceStates"
     :negotiation-id="negotiationId"
     :ui-configuration="uiConfiguration"
     :isAdmin="isAdmin"
-    :is-loading="isLoading"
-    :page-info="pageInfo"
+    :resources-last-updated="resourcesLastUpdated"
     @open-form-modal="openFormModal"
     @open-modal="openModal"
     @update-resource-state="updateResourceState"
     @update-org-status="updateOrgStatus"
     @editInfoSubmission="editInfoSubmission"
-    @change-page="(newPage) => $emit('change-page', newPage)"
   />
 </template>
 
@@ -65,15 +64,17 @@ const props = defineProps({
   resourceStates: { type: Array, default: () => [] },
   negotiationId: { type: String, default: undefined },
   isAdmin: { type: Boolean, default: false },
-  isLoading: { type: Boolean, default: false },
-  pageInfo: { type: Object, default: () => ({ number: 0, totalPages: 0 }) }
+  resourcesLastUpdated: { type: Number, default: 0 },
 })
-const emit = defineEmits(['reloadResources', 'change-page'])
+
+const emit = defineEmits(['reloadResourceInfo'])
 
 const uiConfigurationStore = useUiConfiguration()
 const negotiationPageStore = useNegotiationPageStore()
 const formsStore = useFormsStore()
 const uiConfiguration = computed(() => uiConfigurationStore.uiConfiguration?.theme)
+
+const organizationCardRef = ref(null)
 
 // Modal and Form Data
 const requirementId = ref(undefined)
@@ -89,6 +90,13 @@ const formSubmissionModalInstance = ref(null)
 const formViewModalRef = ref(null)
 const formViewModalInstance = ref(null)
 const isFormEditable = ref(false)
+
+async function reloadLocalCardResources() {
+  if (organizationCardRef.value) {
+    await organizationCardRef.value.fetchResources()
+  }
+  emit('reloadResourceInfo')
+}
 
 const openModal = async (href, resId) => {
   isFormEditable.value = false
@@ -108,19 +116,19 @@ async function openFormModal(href) {
 
 function hideFormSubmissionModal() {
   formSubmissionModalInstance.value.hide()
-  emit('reloadResources')
+  reloadLocalCardResources()
 }
 
 function hideFormSubmissionAndOpenView(payload) {
   submittedForm.value.payload = payload
   formSubmissionModalInstance.value.hide()
-  emit('reloadResources')
+  reloadLocalCardResources()
   formViewModalInstance.value.show()
 }
 
 async function updateResourceState(link) {
   await negotiationPageStore.updateResourceStatus(link)
-  emit('reloadResources')
+  reloadLocalCardResources()
 }
 
 const updateOrgStatus = (state, organization) => {
@@ -142,7 +150,7 @@ const updateOrganization = async () => {
     state: orgStatus.value.value,
   }
   await negotiationPageStore.addResources(data, props.negotiationId)
-  emit('reloadResources')
+  reloadLocalCardResources()
 }
 
 onMounted(() => {

--- a/frontend/src/components/OrganizationContainer.vue
+++ b/frontend/src/components/OrganizationContainer.vue
@@ -92,9 +92,6 @@ const formViewModalInstance = ref(null)
 const isFormEditable = ref(false)
 
 async function reloadLocalCardResources() {
-  if (organizationCardRef.value) {
-    await organizationCardRef.value.fetchResources()
-  }
   emit('reloadResourceInfo')
 }
 

--- a/frontend/src/components/OrganizationContainer.vue
+++ b/frontend/src/components/OrganizationContainer.vue
@@ -149,7 +149,10 @@ const updateOrganization = async () => {
     resourceIds: getRepresentedResources(selectedOrganization.value.resources),
     state: orgStatus.value.value,
   }
-  await negotiationPageStore.addResources(data, props.negotiationId)
+  const wasSuccessful = await negotiationPageStore.addResources(data, props.negotiationId)
+  if (!wasSuccessful) {
+    return
+  }
   reloadLocalCardResources()
 }
 

--- a/frontend/src/components/OrganizationContainer.vue
+++ b/frontend/src/components/OrganizationContainer.vue
@@ -143,7 +143,7 @@ const getRepresentedResources = (resources) =>
 
 const updateOrganization = async () => {
   const data = {
-    resourceIds: getRepresentedResources(selectedOrganization.value.resources),
+    resourceIds: getRepresentedResources(organizationCardRef.value.resources),
     state: orgStatus.value.value,
   }
   const wasSuccessful = await negotiationPageStore.addResources(data, props.negotiationId)

--- a/frontend/src/components/modals/AddResourcesModal.vue
+++ b/frontend/src/components/modals/AddResourcesModal.vue
@@ -194,14 +194,17 @@ const emit = defineEmits(['confirm'])
 
 async function addResources() {
   let data = { resourceIds: selectedResources.value }
-  if (selectedState.value) {
+  if (selectedState.value?.value) {
     data = {
       resourceIds: selectedResources.value,
       state: selectedState.value.value,
     }
   }
   const negotiationId = props.negotiationId
-  await store.addResources(data, negotiationId)
+  const wasSuccessful = await store.addResources(data, negotiationId)
+  if (!wasSuccessful) {
+    return
+  }
   selectedResources.value = []
   emit('confirm')
 }

--- a/frontend/src/store/negotiationPage.js
+++ b/frontend/src/store/negotiationPage.js
@@ -314,16 +314,14 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
 
   async function addResources(data, negotiationId, silent = false) {
     try {
-      const response = await axios.patch(
-        `${apiPaths.BASE_API_PATH}/negotiations/${negotiationId}/resources`,
-        data,
-        { headers: getBearerHeaders() },
-      )
+      await axios.patch(`${apiPaths.BASE_API_PATH}/negotiations/${negotiationId}/resources`, data, {
+        headers: getBearerHeaders(),
+      })
       if (!silent) notifications.setNotification('Resources were successfully updated')
-      return response.data
+      return true
     } catch {
       if (!silent) notifications.setNotification('There was an error saving the attachment')
-      return undefined
+      return false
     }
   }
 

--- a/frontend/src/store/negotiationPage.js
+++ b/frontend/src/store/negotiationPage.js
@@ -183,15 +183,15 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
 
   async function retrieveResourcesByNegotiationInfo(negotiationId) {
     return await axios
-        .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/resources/info`, {
-          headers: getBearerHeaders(),
-        })
-        .then((response) => {
-          return response.data
-        })
-        .catch(() => {
-          notifications.setNotification('Error fetching Resources', 'danger')
-        })
+      .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/resources/info`, {
+        headers: getBearerHeaders(),
+      })
+      .then((response) => {
+        return response.data
+      })
+      .catch(() => {
+        notifications.setNotification('Error fetching Resources', 'danger')
+      })
   }
 
   async function retrieveResourcesByNegotiationId(negotiationId) {
@@ -207,18 +207,22 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
       })
   }
 
-  async function retrieveResourcesByNegotiationIdAndOrganizationIdPaginated(negotiationId, organizationId, { page = 0, size = 20, sort = 'id' } = {}) {
+  async function retrieveResourcesByNegotiationIdAndOrganizationIdPaginated(
+    negotiationId,
+    organizationId,
+    { page = 0, size = 20, sort = 'id' } = {},
+  ) {
     return await axios
-        .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/resources`, {
-          headers: getBearerHeaders(),
-          params: { organizationId, page, size, sort }
-        })
-        .then((response) => {
-          return response.data
-        })
-        .catch(() => {
-          notifications.setNotification('Error fetching Resources', 'danger')
-        })
+      .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/resources`, {
+        headers: getBearerHeaders(),
+        params: { organizationId, page, size, sort },
+      })
+      .then((response) => {
+        return response.data
+      })
+      .catch(() => {
+        notifications.setNotification('Error fetching Resources', 'danger')
+      })
   }
 
   function downloadAttachmentFromLink(href) {
@@ -406,14 +410,14 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
 
   async function retrieveOrganizationsByNegotiationId(negotiationId) {
     return await axios
-        .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/organizations`, {
-          headers: getBearerHeaders(),
-        })
-        .then((response) => response.data)
-        .catch(() => {
-          notifications.setNotification('Error fetching Organizations', 'danger')
-          return null
-        })
+      .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/organizations`, {
+        headers: getBearerHeaders(),
+      })
+      .then((response) => response.data)
+      .catch(() => {
+        notifications.setNotification('Error fetching Organizations', 'danger')
+        return null
+      })
   }
 
   return {

--- a/frontend/src/store/negotiationPage.js
+++ b/frontend/src/store/negotiationPage.js
@@ -194,6 +194,20 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
       })
   }
 
+  async function retrieveResourcesByNegotiationIdPaginated(negotiationId, { page = 0, size = 20, sort = 'id' } = {}) {
+    return await axios
+        .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/resources`, {
+          headers: getBearerHeaders(),
+          params: { page, size, sort }
+        })
+        .then((response) => {
+          return response.data
+        })
+        .catch(() => {
+          notifications.setNotification('Error fetching Resources', 'danger')
+        })
+  }
+
   async function retrieveResourcesByNegotiationIdLinks(negotiationId) {
     return await axios
       .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/resources`, {
@@ -404,6 +418,7 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
     retrieveUserIdRepresentedResources,
     downloadAttachment,
     retrieveResourcesByNegotiationId,
+    retrieveResourcesByNegotiationIdPaginated,
     retrieveResourcesByNegotiationIdLinks,
     downloadAttachmentFromLink,
     retrieveInformationSubmission,

--- a/frontend/src/store/negotiationPage.js
+++ b/frontend/src/store/negotiationPage.js
@@ -56,7 +56,7 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
       .put(url, {}, { headers: getBearerHeaders() })
       .then((response) => {
         notifications.setNotification(
-          `Than you. Your action for Negotiation ${response.data.id} was submitted successfully`,
+          `Thank you. Your action for Negotiation ${response.data.id} was submitted successfully`,
         )
         return response.data
       })
@@ -181,6 +181,19 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
       })
   }
 
+  async function retrieveResourcesByNegotiationInfo(negotiationId) {
+    return await axios
+        .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/resources/info`, {
+          headers: getBearerHeaders(),
+        })
+        .then((response) => {
+          return response.data
+        })
+        .catch(() => {
+          notifications.setNotification('Error fetching Resources', 'danger')
+        })
+  }
+
   async function retrieveResourcesByNegotiationId(negotiationId) {
     return await axios
       .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/resources`, {
@@ -194,11 +207,11 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
       })
   }
 
-  async function retrieveResourcesByNegotiationIdPaginated(negotiationId, { page = 0, size = 20, sort = 'id' } = {}) {
+  async function retrieveResourcesByNegotiationIdAndOrganizationIdPaginated(negotiationId, organizationId, { page = 0, size = 20, sort = 'id' } = {}) {
     return await axios
         .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/resources`, {
           headers: getBearerHeaders(),
-          params: { page, size, sort }
+          params: { organizationId, page, size, sort }
         })
         .then((response) => {
           return response.data
@@ -206,19 +219,6 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
         .catch(() => {
           notifications.setNotification('Error fetching Resources', 'danger')
         })
-  }
-
-  async function retrieveResourcesByNegotiationIdLinks(negotiationId) {
-    return await axios
-      .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/resources`, {
-        headers: getBearerHeaders(),
-      })
-      .then((response) => {
-        return response.data
-      })
-      .catch(() => {
-        notifications.setNotification('Error fetching Resources', 'danger')
-      })
   }
 
   function downloadAttachmentFromLink(href) {
@@ -404,6 +404,18 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
     }
   }
 
+  async function retrieveOrganizationsByNegotiationId(negotiationId) {
+    return await axios
+        .get(`${apiPaths.NEGOTIATION_PATH}/${negotiationId}/organizations`, {
+          headers: getBearerHeaders(),
+        })
+        .then((response) => response.data)
+        .catch(() => {
+          notifications.setNotification('Error fetching Organizations', 'danger')
+          return null
+        })
+  }
+
   return {
     updateNegotiationStatus,
     retrievePossibleEvents,
@@ -417,9 +429,9 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
     addAttachmentToNegotiation,
     retrieveUserIdRepresentedResources,
     downloadAttachment,
+    retrieveResourcesByNegotiationInfo,
     retrieveResourcesByNegotiationId,
-    retrieveResourcesByNegotiationIdPaginated,
-    retrieveResourcesByNegotiationIdLinks,
+    retrieveResourcesByNegotiationIdAndOrganizationIdPaginated,
     downloadAttachmentFromLink,
     retrieveInformationSubmission,
     fetchURL,
@@ -430,5 +442,6 @@ export const useNegotiationPageStore = defineStore('negotiationPage', () => {
     deleteNegotiation,
     retrieveNegotiationPDF,
     retrieveNegotiationTimeline,
+    retrieveOrganizationsByNegotiationId,
   }
 })

--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -331,7 +331,7 @@ const vueTourStore = useVueTourStore()
 const router = useRouter()
 const negotiationPosts = ref(null)
 const timelineEvents = ref([])
-const pageInfo = ref({ number: 0, totalPages: 0, totalElements: 0, size: 20 });
+const pageInfo = ref({ number: 0, totalPages: 0, totalElements: 0, size: 20 })
 const isFetchingResources = ref(false)
 const currentNumberOfResources = ref(0)
 const isFetchingResourceInfo = ref(false)
@@ -402,7 +402,9 @@ const loading = computed(() => {
 })
 
 async function fetchOrganizations() {
-  const response = await negotiationPageStore.retrieveOrganizationsByNegotiationId(props.negotiationId)
+  const response = await negotiationPageStore.retrieveOrganizationsByNegotiationId(
+    props.negotiationId,
+  )
   if (response?._embedded?.organizations) {
     rawOrganizations.value = response._embedded.organizations
   }
@@ -414,7 +416,9 @@ async function fetchResourceInfo() {
   isFetchingResourceInfo.value = true
 
   try {
-    const response = await negotiationPageStore.retrieveResourcesByNegotiationInfo(props.negotiationId)
+    const response = await negotiationPageStore.retrieveResourcesByNegotiationInfo(
+      props.negotiationId,
+    )
 
     if (response !== undefined) {
       currentNumberOfResources.value = response?.count

--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -331,8 +331,6 @@ const vueTourStore = useVueTourStore()
 const router = useRouter()
 const negotiationPosts = ref(null)
 const timelineEvents = ref([])
-const pageInfo = ref({ number: 0, totalPages: 0, totalElements: 0, size: 20 })
-const isFetchingResources = ref(false)
 const currentNumberOfResources = ref(0)
 const isFetchingResourceInfo = ref(false)
 const resourcesLastUpdated = ref(Date.now())
@@ -380,7 +378,7 @@ const notRepresentedOrganizationsById = computed(() => {
 })
 
 const numberOfResources = computed(() => {
-  return currentNumberOfResources ?? 0
+  return currentNumberOfResources.value ?? 0
 })
 
 const postsRecipients = computed(() => {

--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -248,7 +248,10 @@
                     :resources="resources"
                     :resource-states="resourceStates"
                     :isAdmin="isAdmin"
+                    :is-loading="isFetchingResources"
+                    :page-info="pageInfo"
                     @reload-resources="reloadResources()"
+                    @change-page="fetchResources"
                   />
                 </div>
               </div>
@@ -332,6 +335,8 @@ const vueTourStore = useVueTourStore()
 const router = useRouter()
 const negotiationPosts = ref(null)
 const timelineEvents = ref([])
+const pageInfo = ref({ number: 0, totalPages: 0, totalElements: 0, size: 20 });
+const isFetchingResources = ref(false)
 
 const uiConfiguration = computed(() => {
   return uiConfigurationStore.uiConfiguration?.theme
@@ -419,7 +424,7 @@ function isResourceRepresented(resource) {
 }
 
 const numberOfResources = computed(() => {
-  return getResources.value.length
+  return pageInfo.value.totalElements ?? 0
 })
 
 const postsRecipients = computed(() => {
@@ -440,18 +445,42 @@ const loading = computed(() => {
   return negotiation.value === undefined || resources.value.length === 0
 })
 
+//
+//IMPORTANT
+//Make it in OrganizationContainer since the pagination should be for the resources per organization
+//Also causes the bug that on next the organization goes from 2 to 1 and other organization container disappears
+//Maybe introduce an endpoint just to get the number of organizations and total resources for negotiation
+//
+async function fetchResources(targetPage = 0) {
+  if (isFetchingResources.value) return
+
+  isFetchingResources.value = true
+
+  try {
+    const response = await negotiationPageStore.retrieveResourcesByNegotiationIdPaginated(
+        props.negotiationId,
+        { page: targetPage, size: pageInfo.value.size || 20, sort: 'id' }
+    )
+
+    if (response !== undefined) {
+      resources.value = response?._embedded?.resources || []
+
+      if (response?.page) {
+        pageInfo.value = response.page
+      }
+
+      isAddResourcesButtonVisible.value = hasRightsToAddResources(response?._links)
+    }
+  } finally {
+    isFetchingResources.value = false
+  }
+}
+
 onBeforeMount(async () => {
   negotiation.value = await negotiationPageStore.retrieveNegotiationById(props.negotiationId)
-  const resourceResponse = await negotiationPageStore.retrieveResourcesByNegotiationId(
-    props.negotiationId,
-  )
-  if (resourceResponse !== undefined) {
-    resources.value = resourceResponse
-    const resourceResponseLinks = await negotiationPageStore.retrieveResourcesByNegotiationIdLinks(
-      props.negotiationId,
-    )
-    isAddResourcesButtonVisible.value = hasRightsToAddResources(resourceResponseLinks._links)
-  }
+
+  await fetchResources(0)
+
   await negotiationPageStore
     .retrieveUserIdRepresentedResources(userStore.userInfo?.id)
     .then((resp) => {
@@ -539,12 +568,7 @@ function translateTrueFalse(value) {
 }
 
 async function reloadResources() {
-  const resourceResponse = await negotiationPageStore.retrieveResourcesByNegotiationId(
-    props.negotiationId,
-  )
-  if (resourceResponse !== undefined) {
-    resources.value = resourceResponse
-  }
+  await fetchResources(pageInfo.value.number)
   negotiation.value = await negotiationPageStore.retrieveNegotiationById(props.negotiationId)
   timelineEvents.value = await negotiationPageStore.retrieveNegotiationTimeline(props.negotiationId)
 }

--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -256,6 +256,7 @@
           </li>
         </ul>
         <NegotiationPosts
+          data-cy="negotiation-posts"
           ref="negotiationPosts"
           v-if="negotiation"
           :negotiation="negotiation"

--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -223,10 +223,10 @@
                     :org-id="orgId"
                     :org="org"
                     :negotiation-id="negotiationId"
-                    :resources="resources"
                     :resource-states="resourceStates"
                     :isAdmin="isAdmin"
-                    @reload-resources="reloadResources()"
+                    :resources-last-updated="resourcesLastUpdated"
+                    @reload-resource-info="reloadResources()"
                   />
                 </div>
               </div>
@@ -245,13 +245,10 @@
                     :org-id="orgId"
                     :org="org"
                     :negotiation-id="negotiationId"
-                    :resources="resources"
                     :resource-states="resourceStates"
                     :isAdmin="isAdmin"
-                    :is-loading="isFetchingResources"
-                    :page-info="pageInfo"
-                    @reload-resources="reloadResources()"
-                    @change-page="fetchResources"
+                    :resources-last-updated="resourcesLastUpdated"
+                    @reload-resource-info="reloadResources()"
                   />
                 </div>
               </div>
@@ -262,7 +259,6 @@
           ref="negotiationPosts"
           v-if="negotiation"
           :negotiation="negotiation"
-          :resources="resources"
           :organizations="organizationsById"
           :recipients="postsRecipients"
           :external-posts="posts"
@@ -337,55 +333,25 @@ const negotiationPosts = ref(null)
 const timelineEvents = ref([])
 const pageInfo = ref({ number: 0, totalPages: 0, totalElements: 0, size: 20 });
 const isFetchingResources = ref(false)
+const currentNumberOfResources = ref(0)
+const isFetchingResourceInfo = ref(false)
+const resourcesLastUpdated = ref(Date.now())
+const rawOrganizations = ref([])
 
 const uiConfiguration = computed(() => {
   return uiConfigurationStore.uiConfiguration?.theme
 })
-const getResources = computed(() => {
-  return resources.value
-})
+
 const organizations = computed(() => {
   return Object.entries(organizationsById.value).map(([k, v]) => {
     return { externalId: k, name: v.name }
   })
 })
+
 const organizationsById = computed(() => {
-  // Create a map of state ordinals for quick lookup
-  const stateOrdinalMap = resourceStates.value.reduce((map, state) => {
-    map[state.value] = state.ordinal
-    return map
-  }, {})
-
-  return getResources.value.reduce((organizations, resource) => {
-    const currentState = resource.currentState
-    const currentOrdinal = stateOrdinalMap[currentState] || 0 // Default to 0 if no match found
-
-    const orgId = resource.organization.externalId
-
-    if (orgId in organizations) {
-      // Push the resource to the organization's resources array
-      organizations[orgId].resources.push(resource)
-
-      // Check if the current resource state has a higher ordinal
-      const orgStatusOrdinal = stateOrdinalMap[organizations[orgId].status] || 0
-      if (currentOrdinal > orgStatusOrdinal) {
-        organizations[orgId].status = currentState // Update org status to the one with the highest ordinal
-      }
-
-      // Check if the organization has at least one represented resource
-      if (isResourceRepresented(resource)) {
-        organizations[orgId].updatable = true
-      }
-    } else {
-      // Add a new organization entry
-      organizations[orgId] = {
-        name: resource.organization.name,
-        resources: [resource],
-        status: currentState, // Set initial status
-        updatable: isResourceRepresented(resource), // Set updateable to true if any resource is represented
-      }
-    }
-    return organizations
+  return rawOrganizations.value.reduce((acc, org) => {
+    acc[org.externalId] = org
+    return acc
   }, {})
 })
 
@@ -413,18 +379,8 @@ const notRepresentedOrganizationsById = computed(() => {
     .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
 })
 
-// Helper function to check if a resource is represented
-function isResourceRepresented(resource) {
-  for (const key in resource._links) {
-    if (resource._links[key].title === 'Next Lifecycle event') {
-      return true
-    }
-  }
-  return false
-}
-
 const numberOfResources = computed(() => {
-  return pageInfo.value.totalElements ?? 0
+  return currentNumberOfResources ?? 0
 })
 
 const postsRecipients = computed(() => {
@@ -442,44 +398,39 @@ const author = computed(() => {
 })
 
 const loading = computed(() => {
-  return negotiation.value === undefined || resources.value.length === 0
+  return negotiation.value === undefined || rawOrganizations.value.length === 0
 })
 
-//
-//IMPORTANT
-//Make it in OrganizationContainer since the pagination should be for the resources per organization
-//Also causes the bug that on next the organization goes from 2 to 1 and other organization container disappears
-//Maybe introduce an endpoint just to get the number of organizations and total resources for negotiation
-//
-async function fetchResources(targetPage = 0) {
-  if (isFetchingResources.value) return
+async function fetchOrganizations() {
+  const response = await negotiationPageStore.retrieveOrganizationsByNegotiationId(props.negotiationId)
+  if (response?._embedded?.organizations) {
+    rawOrganizations.value = response._embedded.organizations
+  }
+}
 
-  isFetchingResources.value = true
+async function fetchResourceInfo() {
+  if (isFetchingResourceInfo.value) return
+
+  isFetchingResourceInfo.value = true
 
   try {
-    const response = await negotiationPageStore.retrieveResourcesByNegotiationIdPaginated(
-        props.negotiationId,
-        { page: targetPage, size: pageInfo.value.size || 20, sort: 'id' }
-    )
+    const response = await negotiationPageStore.retrieveResourcesByNegotiationInfo(props.negotiationId)
 
     if (response !== undefined) {
-      resources.value = response?._embedded?.resources || []
-
-      if (response?.page) {
-        pageInfo.value = response.page
-      }
+      currentNumberOfResources.value = response?.count
 
       isAddResourcesButtonVisible.value = hasRightsToAddResources(response?._links)
     }
   } finally {
-    isFetchingResources.value = false
+    isFetchingResourceInfo.value = false
   }
 }
 
 onBeforeMount(async () => {
   negotiation.value = await negotiationPageStore.retrieveNegotiationById(props.negotiationId)
 
-  await fetchResources(0)
+  await fetchResourceInfo()
+  await fetchOrganizations()
 
   await negotiationPageStore
     .retrieveUserIdRepresentedResources(userStore.userInfo?.id)
@@ -568,7 +519,9 @@ function translateTrueFalse(value) {
 }
 
 async function reloadResources() {
-  await fetchResources(pageInfo.value.number)
+  await fetchResourceInfo()
+  await fetchOrganizations()
+  resourcesLastUpdated.value = Date.now()
   negotiation.value = await negotiationPageStore.retrieveNegotiationById(props.negotiationId)
   timelineEvents.value = await negotiationPageStore.retrieveNegotiationTimeline(props.negotiationId)
 }

--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -336,6 +336,7 @@ const currentNumberOfResources = ref(0)
 const isFetchingResourceInfo = ref(false)
 const resourcesLastUpdated = ref(Date.now())
 const rawOrganizations = ref([])
+const organizationsLoaded = ref(false)
 
 const uiConfiguration = computed(() => {
   return uiConfigurationStore.uiConfiguration?.theme
@@ -397,15 +398,17 @@ const author = computed(() => {
 })
 
 const loading = computed(() => {
-  return negotiation.value === undefined || rawOrganizations.value.length === 0
+  return negotiation.value === undefined || !organizationsLoaded.value
 })
 
 async function fetchOrganizations() {
-  const response = await negotiationPageStore.retrieveOrganizationsByNegotiationId(
-    props.negotiationId,
-  )
-  if (response?._embedded?.organizations) {
-    rawOrganizations.value = response._embedded.organizations
+  try {
+    const response = await negotiationPageStore.retrieveOrganizationsByNegotiationId(
+      props.negotiationId,
+    )
+    rawOrganizations.value = response?._embedded?.organizations ?? []
+  } finally {
+    organizationsLoaded.value = true
   }
 }
 

--- a/frontend/src/views/NegotiationPage.vue
+++ b/frontend/src/views/NegotiationPage.vue
@@ -256,7 +256,7 @@
           </li>
         </ul>
         <NegotiationPosts
-          data-cy="negotiation-posts"
+          data-test="negotiation-posts"
           ref="negotiationPosts"
           v-if="negotiation"
           :negotiation="negotiation"


### PR DESCRIPTION
### Description:

Added pagination to resource loading on the negotiation page to improve performance with large datasets. Refactored resource fetching to load resources per organization instead of at the negotiation level for better scalability and structure.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
