### PR TITLE
fix: set correct version of wizard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "vue-i18n": "^11.2.8",
     "vue-matomo": "^4.2.0",
     "vue-router": "^5.0.2",
-    "vue3-form-wizard": "^0.2.4",
+    "vue3-form-wizard": "1.1.1",
     "vue3-tour": "^1.0.3",
     "vuedraggable": "4.1.0",
     "yarn": "^1.22.19"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3225,10 +3225,10 @@ vue-router@^5.0.2:
     unplugin-utils "^0.3.1"
     yaml "^2.9.0"
 
-vue3-form-wizard@^0.2.4:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/vue3-form-wizard/-/vue3-form-wizard-0.2.9.tgz#a2b7873f76f77b82898442cbcf9064a25980c08f"
-  integrity sha512-07afis9uJlwJV8+yheQpVkDB9cz48SL8NpeScg1tTBAnacjX33kvt7ywuoitKEw/fx2ZPPu8vyV3swhD9oOKkw==
+vue3-form-wizard@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vue3-form-wizard/-/vue3-form-wizard-1.1.1.tgz#d0c43ddc653bc8ec7f45761772949b204123d864"
+  integrity sha512-VE27FktnSk+gLTvCrSUErJxP9ma3M+9HaHgKDg0ox3M9gDxYqsu6YqKSnJefrvXfYqtHTV8u2YmhWzdQBBYvEg==
 
 vue3-tour@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
### Description:

## Fix: Access Form fields not displayed when editing

### Problem

When editing an Access Form in Admin Settings, only the title and sections were visible — the available and selected fields were not rendered.

**Steps to reproduce:**
1. Log in with administrator role
2. Open **Admin Settings → Access Forms**
3. Select an existing template or click **"Add Access Form"**
4. Add sections — fields are not displayed

### Root Cause

The `vue3-form-wizard` package was installed with the `^` caret prefix (`^1.1.1`), allowing npm to resolve a newer minor version that introduced a breaking change in the Composition API — causing the route navigation error and preventing fields from rendering.

### Fix

Pinned `vue3-form-wizard` to the exact version `1.1.1` in `package.json` to ensure the compatible version is always used.

```json
"vue3-form-wizard": "1.1.1"
```

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
