### PR TITLE
feat: implement GET /v3/posts/{postId} with visibility-aware access control

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/configuration/security/HTTPRegistryConfigurer.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/configuration/security/HTTPRegistryConfigurer.java
@@ -33,6 +33,8 @@ public class HTTPRegistryConfigurer {
         .authenticated()
         .requestMatchers(mvc.pattern("/v3/attachments/**"))
         .authenticated()
+        .requestMatchers(mvc.pattern(HttpMethod.GET, "/v3/posts/**"))
+        .authenticated()
         .requestMatchers(mvc.pattern("/v3/negotiations/**"))
         .authenticated()
         .requestMatchers(mvc.pattern("/v3/access-criteria"))

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostServiceImpl.java
@@ -117,7 +117,15 @@ public class PostServiceImpl implements PostService {
   @Transactional
   public PostDTO findById(String id) {
     Post post = postRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(id));
-    verifyReadAccess(post.getNegotiation().getId());
+    String negotiationId = post.getNegotiation().getId();
+    verifyReadAccess(negotiationId);
+    if (!post.isPublic() && !isNegotiationCreatorOrAdminOrHelpdeskIntegration(negotiationId)) {
+      Person user = getCurrentUser();
+      Set<Organization> accessibleOrganizations = getUserAccessibleOrganizations(user);
+      if (!accessibleOrganizations.contains(post.getOrganization())) {
+        throw new ForbiddenRequestException("You are not authorized to read this post");
+      }
+    }
     return modelMapper.map(post, PostDTO.class);
   }
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostServiceImpl.java
@@ -114,8 +114,11 @@ public class PostServiceImpl implements PostService {
   }
 
   @Override
+  @Transactional
   public PostDTO findById(String id) {
-    return null;
+    Post post = postRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(id));
+    verifyReadAccess(post.getNegotiation().getId());
+    return modelMapper.map(post, PostDTO.class);
   }
 
   @NonNull

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/PostControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/PostControllerTests.java
@@ -43,6 +43,8 @@ public class PostControllerTests {
   private static final String NEGOTIATION_HELPDESK_ID = "negotiation-helpdesk";
   private static final String NEGOTIATION_HELPDESK_ORGANIZATION_ID = "biobank:1";
   public static final String NEGOTIATION_POSTS_URL = "/v3/negotiations/%s/posts";
+  private static final String POSTS_ENDPOINT_URI = "/v3/posts";
+  private static final String POST_1_RESEARCHER_ID = "post-1-researcher";
   @Autowired private PostRepository postRepository;
   @Autowired private MockMvc mockMvc;
 
@@ -114,7 +116,7 @@ public class PostControllerTests {
     String postId = JsonPath.read(result.getResponse().getContentAsString(), "$.id");
     Optional<Post> post = postRepository.findById(postId);
     assert post.isPresent();
-    assertEquals(post.get().getCreatedBy().getName(), "TheResearcher");
+    assertEquals("TheResearcher", post.get().getCreatedBy().getName());
   }
 
   @Test
@@ -300,5 +302,23 @@ public class PostControllerTests {
     Optional<Post> post = postRepository.findById(postId);
     assertTrue(post.isPresent());
     assertNull(post.get().getHelpdeskActor());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(authorities = "ROLE_HELPDESK_INTEGRATION", id = 110L)
+  void getPostById_asHelpdeskIntegration_ok() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON))
+        .andExpect(jsonPath("$.id", is(POST_1_RESEARCHER_ID)));
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 104L)
+  void getPostById_notParticipant_forbidden() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
+        .andExpect(status().isForbidden());
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/PostControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/PostControllerTests.java
@@ -46,6 +46,9 @@ public class PostControllerTests {
   public static final String NEGOTIATION_POSTS_URL = "/v3/negotiations/%s/posts";
   private static final String POSTS_ENDPOINT_URI = "/v3/posts";
   private static final String POST_1_RESEARCHER_ID = "post-1-researcher";
+  private static final String POST_3_REPRESENTATIVE_ID = "post-3-representative";
+  private static final String POST_3_RESEARCHER_ID = "post-3-researcher";
+  private static final String POST_4_REPRESENTATIVE_ID = "post-4-representative";
   @Autowired private PostRepository postRepository;
   @Autowired private MockMvc mockMvc;
 
@@ -310,7 +313,7 @@ public class PostControllerTests {
 
   @Test
   @WithMockNegotiatorUser(authorities = "ROLE_HELPDESK_INTEGRATION", id = 110L)
-  void getPostById_asHelpdeskIntegration_ok() throws Exception {
+  void getPostById_asHelpdeskIntegration_publicPost_ok() throws Exception {
     mockMvc
         .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
         .andExpect(status().isOk())
@@ -319,10 +322,77 @@ public class PostControllerTests {
   }
 
   @Test
+  @WithMockNegotiatorUser(authorities = "ROLE_HELPDESK_INTEGRATION", id = 110L)
+  void getPostById_asHelpdeskIntegration_privatePost_ok() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_3_REPRESENTATIVE_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON))
+        .andExpect(jsonPath("$.id", is(POST_3_REPRESENTATIVE_ID)));
+  }
+
+  @Test
   @WithMockNegotiatorUser(id = 104L)
   void getPostById_notParticipant_forbidden() throws Exception {
     mockMvc
         .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
         .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 101L, authorities = "ROLE_ADMIN")
+  void getPostById_asAdmin_publicPost_ok() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 101L, authorities = "ROLE_ADMIN")
+  void getPostById_asAdmin_privatePost_ok() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_3_RESEARCHER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 108L)
+  void getPostById_asCreator_publicPost_ok() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 108L)
+  void getPostById_asCreator_privatePost_ok() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_3_RESEARCHER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 103L)
+  void getPostById_isParticipantButNotPartOfOrganization_forbidden() throws Exception {
+    // Person 103 is a participant of negotiation-1 (represents resource 4 / biobank:1)
+    // but post-4-representative is private and addressed to org 5 (biobank:2)
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_4_REPRESENTATIVE_ID)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 103L)
+  void getPostById_isPartOfOrganizationFromNegotiatedResource_ok() throws Exception {
+    // Person 103 represents resource 4 (biobank:1, org id 4) — post-3-researcher is private for org
+    // 4
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_3_RESEARCHER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON));
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/PostControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/PostControllerTests.java
@@ -388,8 +388,8 @@ public class PostControllerTests {
   @Test
   @WithMockNegotiatorUser(id = 103L)
   void getPostById_isPartOfOrganizationFromNegotiatedResource_ok() throws Exception {
-    // Person 103 represents resource 4 (biobank:1, org id 4) — post-3-researcher is private for org
-    // 4
+    // Person 103 represents resource 4 (biobank:1, org id 4) — post-3-researcher is private for
+    // organization 4
     mockMvc
         .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_3_RESEARCHER_ID)))
         .andExpect(status().isOk())


### PR DESCRIPTION
### Description:

The GET /v3/posts/{postId} endpoint existed in PostController but was unreachable and non-functional: the path fell through to the catch-all denyAll() security rule, and PostServiceImpl.findById() was an unimplemented stub returning null. This PR implements the endpoint to support the helpdesk integration middleware, which needs to fetch full post text by ID when relaying a negotiation.post.added webhook to the help desk.

The implementation applies the same visibility rules as the existing post-listing endpoint: public posts are readable by any negotiation participant; private posts are only accessible to the negotiation creator, admins, helpdesk integration callers, or participants whose organization matches the post's target organization. Callers holding ROLE_HELPDESK_INTEGRATION bypass the negotiation participant check entirely, as the middleware must be able to relay any post regardless of which organization it is addressed to.

The PR covers Change 4 from integration plan as described in [helpdesk-integration-plan.md](https://github.com/BBMRI-ERIC/negotiator-link/blob/master/docs/helpdesk-integration-plan.md).

### Checklist:

**Required for all pull requests:**
  - [x] I have performed a self-review of my code
  - [x] I have made my code as simple as possible
  - [x] I have removed all commented code
  - [x] I have described the PR and added a meaningful title in the Conventional Commits format

**If applicable to this PR:**
  - [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
  - [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)