### PR TITLE
feat: implement GET /v3/negotiations/{negotiationId}/posts/{postId} with visibility-aware access control

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/configuration/security/HTTPRegistryConfigurer.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/configuration/security/HTTPRegistryConfigurer.java
@@ -33,8 +33,6 @@ public class HTTPRegistryConfigurer {
         .authenticated()
         .requestMatchers(mvc.pattern("/v3/attachments/**"))
         .authenticated()
-        .requestMatchers(mvc.pattern(HttpMethod.GET, "/v3/posts/**"))
-        .authenticated()
         .requestMatchers(mvc.pattern("/v3/negotiations/**"))
         .authenticated()
         .requestMatchers(mvc.pattern("/v3/access-criteria"))

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/common/configuration/security/HTTPRegistryConfigurer.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/common/configuration/security/HTTPRegistryConfigurer.java
@@ -33,6 +33,8 @@ public class HTTPRegistryConfigurer {
         .authenticated()
         .requestMatchers(mvc.pattern("/v3/attachments/**"))
         .authenticated()
+        .requestMatchers(mvc.pattern(HttpMethod.GET, "/v3/posts/**"))
+        .authenticated()
         .requestMatchers(mvc.pattern("/v3/negotiations/**"))
         .authenticated()
         .requestMatchers(mvc.pattern("/v3/access-criteria"))

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostController.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostController.java
@@ -64,9 +64,12 @@ public class PostController {
     return postModelAssembler.toModel(postService.update(createDTO, negotiationId, postId));
   }
 
-  @GetMapping(value = "/posts/{postId}", produces = MediaTypes.HAL_JSON_VALUE)
+  @GetMapping(
+      value = "/negotiations/{negotiationId}/posts/{postId}",
+      produces = MediaTypes.HAL_JSON_VALUE)
   @Operation(summary = "Find a post by an id")
-  EntityModel<PostDTO> getById(@PathVariable @Valid String postId) {
-    return postModelAssembler.toModel(postService.findById(postId));
+  EntityModel<PostDTO> getById(
+      @Valid @PathVariable String negotiationId, @PathVariable @Valid String postId) {
+    return postModelAssembler.toModel(postService.findById(negotiationId, postId));
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostDTO.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostDTO.java
@@ -20,6 +20,7 @@ import org.springframework.hateoas.server.core.Relation;
 @Relation(itemRelation = "post", collectionRelation = "posts")
 public class PostDTO {
   @NonNull private String id;
+  @NonNull private String negotiationId;
   @NonNull private String text;
   @NonNull private LocalDateTime creationDate;
   @NonNull private UserResponseModel createdBy;

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostModelAssembler.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostModelAssembler.java
@@ -21,7 +21,9 @@ public class PostModelAssembler
   @Override
   public @NonNull EntityModel<PostDTO> toModel(@NonNull PostDTO entity) {
     List<Link> links = new ArrayList<>();
-    links.add(linkTo(methodOn(PostController.class).getById(entity.getId())).withSelfRel());
+    links.add(
+        linkTo(methodOn(PostController.class).getById(entity.getNegotiationId(), entity.getId()))
+            .withSelfRel());
     return EntityModel.of(entity, links);
   }
 

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostService.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostService.java
@@ -15,12 +15,13 @@ public interface PostService {
   PostDTO create(PostCreateDTO postRequest, String negotiationId);
 
   /**
-   * Find a post by id.
+   * Find a post by id within a negotiation.
    *
+   * @param negotiationId the id of the negotiation
    * @param id the id of the post
    * @return post
    */
-  PostDTO findById(String id);
+  PostDTO findById(String negotiationId, String id);
 
   /**
    * Finds all the posts related to a Negotiation

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostServiceImpl.java
@@ -120,8 +120,11 @@ public class PostServiceImpl implements PostService {
     verifyReadAccess(negotiationId);
     if (!post.isPublic() && !isNegotiationCreatorOrAdmin(negotiationId)) {
       Person user = getCurrentUser();
-      Set<Organization> accessibleOrganizations = getUserAccessibleOrganizations(user);
-      if (!accessibleOrganizations.contains(post.getOrganization())) {
+      boolean isRepresentativeOfPostOrganization =
+          post.getOrganization().getResources().stream()
+              .flatMap(resource -> resource.getRepresentatives().stream())
+              .anyMatch(person -> person.getId().equals(user.getId()));
+      if (!isRepresentativeOfPostOrganization) {
         throw new ForbiddenRequestException("You are not authorized to read this post");
       }
     }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostServiceImpl.java
@@ -113,8 +113,19 @@ public class PostServiceImpl implements PostService {
   }
 
   @Override
+  @Transactional
   public PostDTO findById(String id) {
-    return null;
+    Post post = postRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(id));
+    String negotiationId = post.getNegotiation().getId();
+    verifyReadAccess(negotiationId);
+    if (!post.isPublic() && !isNegotiationCreatorOrAdmin(negotiationId)) {
+      Person user = getCurrentUser();
+      Set<Organization> accessibleOrganizations = getUserAccessibleOrganizations(user);
+      if (!accessibleOrganizations.contains(post.getOrganization())) {
+        throw new ForbiddenRequestException("You are not authorized to read this post");
+      }
+    }
+    return modelMapper.map(post, PostDTO.class);
   }
 
   @NonNull

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostServiceImpl.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/post/PostServiceImpl.java
@@ -114,9 +114,11 @@ public class PostServiceImpl implements PostService {
 
   @Override
   @Transactional
-  public PostDTO findById(String id) {
+  public PostDTO findById(String negotiationId, String id) {
+    if (!negotiationRepository.existsById(negotiationId)) {
+      throw new EntityNotFoundException(negotiationId);
+    }
     Post post = postRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(id));
-    String negotiationId = post.getNegotiation().getId();
     verifyReadAccess(negotiationId);
     if (!post.isPublic() && !isNegotiationCreatorOrAdmin(negotiationId)) {
       Person user = getCurrentUser();

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/PostControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/PostControllerTests.java
@@ -39,7 +39,8 @@ public class PostControllerTests {
   private static final String NEGOTIATIONS_URI = "/v3/negotiations";
   private static final String POSTS_URI = "posts";
   public static final String NEGOTIATION_POSTS_URL = "/v3/negotiations/%s/posts";
-  private static final String POSTS_ENDPOINT_URI = "/v3/posts";
+  private static final String POSTS_ENDPOINT_URI =
+      "/v3/negotiations/" + NEGOTIATION_1_ID + "/posts";
   private static final String POST_1_RESEARCHER_ID = "post-1-researcher";
   private static final String POST_3_RESEARCHER_ID = "post-3-researcher";
   private static final String POST_4_REPRESENTATIVE_ID = "post-4-representative";
@@ -213,6 +214,14 @@ public class PostControllerTests {
   }
 
   @Test
+  @WithMockNegotiatorUser(id = 108L)
+  void getPostById_nonExistingNegotiation_notFound() throws Exception {
+    mockMvc
+        .perform(get("/v3/negotiations/non-existing-negotiation/posts/" + POST_1_RESEARCHER_ID))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
   @WithMockNegotiatorUser(id = 104L)
   void getPostById_notParticipant_forbidden() throws Exception {
     mockMvc
@@ -234,7 +243,13 @@ public class PostControllerTests {
     mockMvc
         .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+        .andExpect(content().contentType(MediaTypes.HAL_JSON))
+        .andExpect(jsonPath("$.id").value(POST_1_RESEARCHER_ID))
+        .andExpect(jsonPath("$.negotiationId").value(NEGOTIATION_1_ID))
+        .andExpect(jsonPath("$.text").value("post-1-researcher-message"))
+        .andExpect(jsonPath("$.type").value(PostType.PUBLIC.toString()))
+        .andExpect(jsonPath("$.organizationId").doesNotExist())
+        .andExpect(jsonPath("$.createdBy.name").value("TheResearcher"));
   }
 
   @Test
@@ -243,7 +258,13 @@ public class PostControllerTests {
     mockMvc
         .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_3_RESEARCHER_ID)))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+        .andExpect(content().contentType(MediaTypes.HAL_JSON))
+        .andExpect(jsonPath("$.id").value(POST_3_RESEARCHER_ID))
+        .andExpect(jsonPath("$.negotiationId").value(NEGOTIATION_1_ID))
+        .andExpect(jsonPath("$.text").value("post-3-researcher-message"))
+        .andExpect(jsonPath("$.type").value(PostType.PRIVATE.toString()))
+        .andExpect(jsonPath("$.organizationId").value(NEGOTIATION_1_ORGANIZATION_ID))
+        .andExpect(jsonPath("$.createdBy.name").value("TheResearcher"));
   }
 
   @Test
@@ -252,7 +273,13 @@ public class PostControllerTests {
     mockMvc
         .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+        .andExpect(content().contentType(MediaTypes.HAL_JSON))
+        .andExpect(jsonPath("$.id").value(POST_1_RESEARCHER_ID))
+        .andExpect(jsonPath("$.negotiationId").value(NEGOTIATION_1_ID))
+        .andExpect(jsonPath("$.text").value("post-1-researcher-message"))
+        .andExpect(jsonPath("$.type").value(PostType.PUBLIC.toString()))
+        .andExpect(jsonPath("$.organizationId").doesNotExist())
+        .andExpect(jsonPath("$.createdBy.name").value("TheResearcher"));
   }
 
   @Test
@@ -261,7 +288,13 @@ public class PostControllerTests {
     mockMvc
         .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_3_RESEARCHER_ID)))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+        .andExpect(content().contentType(MediaTypes.HAL_JSON))
+        .andExpect(jsonPath("$.id").value(POST_3_RESEARCHER_ID))
+        .andExpect(jsonPath("$.negotiationId").value(NEGOTIATION_1_ID))
+        .andExpect(jsonPath("$.text").value("post-3-researcher-message"))
+        .andExpect(jsonPath("$.type").value(PostType.PRIVATE.toString()))
+        .andExpect(jsonPath("$.organizationId").value(NEGOTIATION_1_ORGANIZATION_ID))
+        .andExpect(jsonPath("$.createdBy.name").value("TheResearcher"));
   }
 
   @Test

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/PostControllerTests.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/api/v3/PostControllerTests.java
@@ -39,6 +39,10 @@ public class PostControllerTests {
   private static final String NEGOTIATIONS_URI = "/v3/negotiations";
   private static final String POSTS_URI = "posts";
   public static final String NEGOTIATION_POSTS_URL = "/v3/negotiations/%s/posts";
+  private static final String POSTS_ENDPOINT_URI = "/v3/posts";
+  private static final String POST_1_RESEARCHER_ID = "post-1-researcher";
+  private static final String POST_3_RESEARCHER_ID = "post-3-researcher";
+  private static final String POST_4_REPRESENTATIVE_ID = "post-4-representative";
   @Autowired private PostRepository postRepository;
   @Autowired private MockMvc mockMvc;
 
@@ -110,7 +114,7 @@ public class PostControllerTests {
     String postId = JsonPath.read(result.getResponse().getContentAsString(), "$.id");
     Optional<Post> post = postRepository.findById(postId);
     assert post.isPresent();
-    assertEquals(post.get().getCreatedBy().getName(), "TheResearcher");
+    assertEquals("TheResearcher", post.get().getCreatedBy().getName());
   }
 
   @Test
@@ -206,5 +210,78 @@ public class PostControllerTests {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
         .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 104L)
+  void getPostById_notParticipant_forbidden() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(authorities = "ROLE_HELPDESK_INTEGRATION", id = 110L)
+  void getPostById_notParticipantWithHelpdeskIntegrationRole_forbidden() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 101L, authorities = "ROLE_ADMIN")
+  void getPostById_asAdmin_publicPost_ok() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 101L, authorities = "ROLE_ADMIN")
+  void getPostById_asAdmin_privatePost_ok() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_3_RESEARCHER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 108L)
+  void getPostById_asCreator_publicPost_ok() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_1_RESEARCHER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 108L)
+  void getPostById_asCreator_privatePost_ok() throws Exception {
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_3_RESEARCHER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON));
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 103L)
+  void getPostById_isParticipantButNotPartOfOrganization_forbidden() throws Exception {
+    // Person 103 is a participant of negotiation-1 (represents resource 4 / biobank:1)
+    // but post-4-representative is private and addressed to org 5 (biobank:2)
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_4_REPRESENTATIVE_ID)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockNegotiatorUser(id = 103L)
+  void getPostById_isPartOfOrganizationFromNegotiatedResource_ok() throws Exception {
+    // Person 103 represents resource 4 (biobank:1, org id 4) — post-3-researcher is private for
+    // organization 4
+    mockMvc
+        .perform(get(String.format("%s/%s", POSTS_ENDPOINT_URI, POST_3_RESEARCHER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.HAL_JSON));
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/unit/controller/PostControllerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/unit/controller/PostControllerTest.java
@@ -1,6 +1,6 @@
 package eu.bbmri_eric.negotiator.unit.controller;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -38,13 +38,14 @@ public class PostControllerTest {
     PostDTO postDTO =
         PostDTO.builder()
             .id("test-id")
+            .negotiationId("negotiation-id")
             .type(PostType.PUBLIC)
             .text("test comment")
             .creationDate(LocalDateTime.now())
             .createdBy(new UserResponseModel())
             .build();
-    when(postService.findById(any())).thenReturn(postDTO);
-    mvc.perform(MockMvcRequestBuilders.get("/v3/posts/test-id"))
+    when(postService.findById(eq("negotiation-id"), eq("test-id"))).thenReturn(postDTO);
+    mvc.perform(MockMvcRequestBuilders.get("/v3/negotiations/negotiation-id/posts/test-id"))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaTypes.HAL_JSON_VALUE))
         .andExpect(jsonPath("$.id").value("test-id"))

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/unit/mappers/PostModelMapperTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/unit/mappers/PostModelMapperTest.java
@@ -28,12 +28,13 @@ public class PostModelMapperTest {
         Post.builder()
             .id("test-id")
             .type(PostType.PUBLIC)
-            .negotiation(new Negotiation())
+            .negotiation(Negotiation.builder().id("test-negotiation-id").build())
             .text("This is important")
             .build();
     post.setCreationDate(LocalDateTime.now());
     post.setCreatedBy(new Person());
     PostDTO postDTO = mapper.map(post, PostDTO.class);
     assertEquals(post.getText(), postDTO.getText());
+    assertEquals(post.getNegotiation().getId(), postDTO.getNegotiationId());
   }
 }

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/unit/service/PostServiceTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/unit/service/PostServiceTest.java
@@ -318,6 +318,7 @@ public class PostServiceTest {
     PostDTO postDTO =
         PostDTO.builder()
             .id("test-id")
+            .negotiationId(NEG_1)
             .creationDate(LocalDateTime.now())
             .createdBy(new UserResponseModel())
             .text(privateResToOrg1.getText())
@@ -367,6 +368,7 @@ public class PostServiceTest {
     PostDTO postDTO =
         PostDTO.builder()
             .id("test-id")
+            .negotiationId(NEG_1)
             .createdBy(new UserResponseModel())
             .creationDate(LocalDateTime.now())
             .text(publicPost1.getText())


### PR DESCRIPTION
### Description:

The GET /v3/posts/{postId} endpoint existed in PostController but was unreachable and non-functional: the path fell through to the catch-all denyAll() security rule, and PostServiceImpl.findById() was an unimplemented stub returning null. This PR implements the endpoint to support the helpdesk integration middleware, which needs to fetch full post text by ID when relaying a negotiation.post.added webhook to the help desk.

The implementation applies the same visibility rules as the existing post-listing endpoint: public posts are readable by any negotiation participant; private posts are only accessible to the negotiation creator, admins, or participants whose organization matches the post's target organization.

### Checklist:

**Required for all pull requests:**
  - [x] I have performed a self-review of my code
  - [x] I have made my code as simple as possible
  - [x] I have removed all commented code
  - [x] I have described the PR and added a meaningful title in the Conventional Commits format

**If applicable to this PR:**
  - [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
  - [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)