### PR TITLE
feat: add involvedOrganizationExternalIds to negotiation.state.updated webhook event

### DIFF
--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/state_machine/negotiation/NegotiationStateChangeEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/state_machine/negotiation/NegotiationStateChangeEvent.java
@@ -1,5 +1,6 @@
 package eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation;
 
+import java.util.Set;
 import lombok.Getter;
 import org.springframework.context.ApplicationEvent;
 
@@ -10,17 +11,20 @@ public class NegotiationStateChangeEvent extends ApplicationEvent {
   private final NegotiationState fromState;
   private final NegotiationState toState;
   private final NegotiationEvent event;
+  private final Set<String> involvedOrganizationExternalIds;
 
   public NegotiationStateChangeEvent(
       Object source,
       String negotiationId,
       NegotiationState fromState,
       NegotiationState toState,
-      NegotiationEvent event) {
+      NegotiationEvent event,
+      Set<String> involvedOrganizationExternalIds) {
     super(source);
     this.negotiationId = negotiationId;
     this.fromState = fromState;
     this.toState = toState;
     this.event = event;
+    this.involvedOrganizationExternalIds = involvedOrganizationExternalIds;
   }
 }

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/state_machine/negotiation/PersistStateChangeListener.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/negotiation/state_machine/negotiation/PersistStateChangeListener.java
@@ -9,7 +9,10 @@ import eu.bbmri_eric.negotiator.user.Person;
 import eu.bbmri_eric.negotiator.user.PersonRepository;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.apachecommons.CommonsLog;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.lang.Nullable;
@@ -59,11 +62,14 @@ public class PersistStateChangeListener
     if (Objects.nonNull(postSenderId) && Objects.nonNull(postBody) && !postBody.isEmpty()) {
       createPostFromMessage(postSenderId, negotiation, postBody);
     }
-    publishChangeEvent(state, transition, negotiationId);
+    publishChangeEvent(state, transition, negotiationId, negotiation);
   }
 
   private void publishChangeEvent(
-      State<String, String> state, Transition<String, String> transition, String negotiationId) {
+      State<String, String> state,
+      Transition<String, String> transition,
+      String negotiationId,
+      Negotiation negotiation) {
     NegotiationEvent event;
     NegotiationState fromState;
     NegotiationState toState;
@@ -76,8 +82,16 @@ public class PersistStateChangeListener
       return;
     }
 
+    Set<String> orgExternalIds =
+        negotiation == null
+            ? Collections.emptySet()
+            : negotiation.getResources().stream()
+                .map(r -> r.getOrganization().getExternalId())
+                .collect(Collectors.toSet());
+
     eventPublisher.publishEvent(
-        new NegotiationStateChangeEvent(this, negotiationId, fromState, toState, event));
+        new NegotiationStateChangeEvent(
+            this, negotiationId, fromState, toState, event, orgExternalIds));
   }
 
   private void createPostFromMessage(Long postSenderId, Negotiation negotiation, String postBody) {

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationStateChangeWebhookMappingStrategy.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationStateChangeWebhookMappingStrategy.java
@@ -33,7 +33,11 @@ class NegotiationStateChangeWebhookMappingStrategy
 
     NegotiationStateUpdatedWebhookEvent payload =
         new NegotiationStateUpdatedWebhookEvent(
-            event.getNegotiationId(), event.getFromState(), event.getToState(), event.getEvent());
+            event.getNegotiationId(),
+            event.getFromState(),
+            event.getToState(),
+            event.getEvent(),
+            event.getInvolvedOrganizationExternalIds());
     return Optional.of(
         new WebhookPayloadEnvelope<>(
             WebhookEventType.NEGOTIATION_STATE_UPDATED,

--- a/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationStateUpdatedWebhookEvent.java
+++ b/backend/src/main/java/eu/bbmri_eric/negotiator/webhook/event/NegotiationStateUpdatedWebhookEvent.java
@@ -3,6 +3,7 @@ package eu.bbmri_eric.negotiator.webhook.event;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationEvent;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Set;
 
 /**
  * Webhook data payload for a negotiation state transition.
@@ -11,6 +12,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * @param fromState source negotiation state before transition
  * @param toState target negotiation state after transition
  * @param event state-machine event that triggered the transition
+ * @param involvedOrganizationExternalIds external IDs of all organizations with resources in this
+ *     negotiation
  */
 @WebhookEventDoc(
     summary = "Negotiation state changed",
@@ -24,4 +27,8 @@ record NegotiationStateUpdatedWebhookEvent(
     @Schema(description = "Target state after transition", example = "SUBMITTED")
         NegotiationState toState,
     @Schema(description = "State-machine event that triggered the transition", example = "SUBMIT")
-        NegotiationEvent event) {}
+        NegotiationEvent event,
+    @Schema(
+            description = "External IDs of all organizations with resources in this negotiation",
+            example = "[\"bbmri:DE:MHH\", \"bbmri:NL:AMC\"]")
+        Set<String> involvedOrganizationExternalIds) {}

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/NegotiationLifecycleServiceImplTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/NegotiationLifecycleServiceImplTest.java
@@ -140,6 +140,18 @@ public class NegotiationLifecycleServiceImplTest {
             negotiationService.findById(negotiationDTO.getId(), false).getStatus()));
     long numEvents = events.stream(NegotiationStateChangeEvent.class).count();
     assertThat(numEvents).isEqualTo(1);
+    Set<String> expectedOrgExternalIds =
+        negotiationRepository
+            .findDetailedById(negotiationDTO.getId())
+            .orElseThrow()
+            .getResources()
+            .stream()
+            .map(r -> r.getOrganization().getExternalId())
+            .collect(Collectors.toSet());
+    NegotiationStateChangeEvent publishedEvent =
+        events.stream(NegotiationStateChangeEvent.class).findFirst().orElseThrow();
+    assertThat(publishedEvent.getInvolvedOrganizationExternalIds())
+        .isEqualTo(expectedOrgExternalIds);
   }
 
   @Test

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookEventListenerIntegrationTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/integration/service/WebhookEventListenerIntegrationTest.java
@@ -32,6 +32,7 @@ import eu.bbmri_eric.negotiator.webhook.WebhookHeaders;
 import eu.bbmri_eric.negotiator.webhook.WebhookRepository;
 import eu.bbmri_eric.negotiator.webhook.event.WebhookEventType;
 import java.time.Duration;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -79,7 +80,8 @@ class WebhookEventListenerIntegrationTest {
             "negotiation-1",
             NegotiationState.SUBMITTED,
             NegotiationState.IN_PROGRESS,
-            NegotiationEvent.APPROVE));
+            NegotiationEvent.APPROVE,
+            Set.of("bbmri:DE:MHH")));
 
     await()
         .atMost(Duration.ofSeconds(5))
@@ -98,7 +100,11 @@ class WebhookEventListenerIntegrationTest {
                           matchingJsonPath("$.data.negotiationId", equalTo("negotiation-1")))
                       .withRequestBody(matchingJsonPath("$.data.fromState", equalTo("SUBMITTED")))
                       .withRequestBody(matchingJsonPath("$.data.toState", equalTo("IN_PROGRESS")))
-                      .withRequestBody(matchingJsonPath("$.data.event", equalTo("APPROVE"))));
+                      .withRequestBody(matchingJsonPath("$.data.event", equalTo("APPROVE")))
+                      .withRequestBody(
+                          matchingJsonPath(
+                              "$.data.involvedOrganizationExternalIds[0]",
+                              equalTo("bbmri:DE:MHH"))));
               wireMockServer.verify(
                   1,
                   postRequestedFor(urlEqualTo("/negotiation-two"))
@@ -130,7 +136,8 @@ class WebhookEventListenerIntegrationTest {
             "negotiation-1",
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT));
+            NegotiationEvent.SUBMIT,
+            Set.of()));
 
     await()
         .atMost(Duration.ofSeconds(5))

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/notification/internal/NegotiationInProgressHandlerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/notification/internal/NegotiationInProgressHandlerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationEvent;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
 import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationStateChangeEvent;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +40,8 @@ class NegotiationInProgressHandlerTest {
             negotiationId,
             NegotiationState.SUBMITTED,
             NegotiationState.IN_PROGRESS,
-            NegotiationEvent.APPROVE);
+            NegotiationEvent.APPROVE,
+            Set.of());
 
     handler.notify(event);
 
@@ -55,7 +57,8 @@ class NegotiationInProgressHandlerTest {
             negotiationId,
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     handler.notify(event);
 
@@ -71,7 +74,8 @@ class NegotiationInProgressHandlerTest {
             negotiationId,
             NegotiationState.SUBMITTED,
             NegotiationState.IN_PROGRESS,
-            NegotiationEvent.APPROVE);
+            NegotiationEvent.APPROVE,
+            Set.of());
 
     handler.notify(event);
 

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/notification/internal/NegotiationStatusChangeHandlerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/notification/internal/NegotiationStatusChangeHandlerTest.java
@@ -14,6 +14,7 @@ import eu.bbmri_eric.negotiator.notification.NotificationService;
 import eu.bbmri_eric.negotiator.user.Person;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,7 +64,8 @@ class NegotiationStatusChangeHandlerTest {
             negotiationId,
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     when(negotiationRepository.findById(negotiationId)).thenReturn(Optional.of(negotiation));
 
@@ -94,7 +96,8 @@ class NegotiationStatusChangeHandlerTest {
             negotiationId,
             NegotiationState.SUBMITTED,
             NegotiationState.IN_PROGRESS,
-            NegotiationEvent.APPROVE);
+            NegotiationEvent.APPROVE,
+            Set.of());
 
     when(negotiationRepository.findById(negotiationId)).thenReturn(Optional.of(negotiation));
 
@@ -124,7 +127,8 @@ class NegotiationStatusChangeHandlerTest {
             negotiationId,
             NegotiationState.IN_PROGRESS,
             NegotiationState.DECLINED,
-            NegotiationEvent.DECLINE);
+            NegotiationEvent.DECLINE,
+            Set.of());
 
     when(negotiationRepository.findById(negotiationId)).thenReturn(Optional.of(negotiation));
 
@@ -154,7 +158,8 @@ class NegotiationStatusChangeHandlerTest {
             negotiationId,
             NegotiationState.IN_PROGRESS,
             NegotiationState.ABANDONED,
-            NegotiationEvent.ABANDON);
+            NegotiationEvent.ABANDON,
+            Set.of());
 
     when(negotiationRepository.findById(negotiationId)).thenReturn(Optional.of(negotiation));
 
@@ -184,7 +189,8 @@ class NegotiationStatusChangeHandlerTest {
             negotiationId,
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     when(negotiationRepository.findById(negotiationId)).thenReturn(Optional.empty());
 
@@ -205,7 +211,8 @@ class NegotiationStatusChangeHandlerTest {
             negotiationId,
             NegotiationState.DRAFT,
             NegotiationState.DRAFT,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     // When
     handler.notify(event);
@@ -227,7 +234,8 @@ class NegotiationStatusChangeHandlerTest {
             negotiationId,
             NegotiationState.SUBMITTED,
             NegotiationState.IN_PROGRESS,
-            NegotiationEvent.APPROVE);
+            NegotiationEvent.APPROVE,
+            Set.of());
     handler.notify(inProgressEvent);
 
     ArgumentCaptor<NotificationCreateDTO> captor =
@@ -248,7 +256,8 @@ class NegotiationStatusChangeHandlerTest {
             negotiationId,
             NegotiationState.IN_PROGRESS,
             NegotiationState.DECLINED,
-            NegotiationEvent.DECLINE);
+            NegotiationEvent.DECLINE,
+            Set.of());
     handler.notify(declinedEvent);
 
     verify(notificationService, times(1)).createNotifications(captor.capture());
@@ -266,7 +275,8 @@ class NegotiationStatusChangeHandlerTest {
             negotiationId,
             NegotiationState.IN_PROGRESS,
             NegotiationState.ABANDONED,
-            NegotiationEvent.ABANDON);
+            NegotiationEvent.ABANDON,
+            Set.of());
     handler.notify(abandonedEvent);
 
     verify(notificationService, times(1)).createNotifications(captor.capture());

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/notification/internal/NegotiationSubmissionHandlerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/notification/internal/NegotiationSubmissionHandlerTest.java
@@ -13,6 +13,7 @@ import eu.bbmri_eric.negotiator.user.PersonRepository;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,7 +54,8 @@ class NegotiationSubmissionHandlerTest {
             negotiationId,
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     Person admin1 = createPerson(1L, "admin1@test.com");
     Person admin2 = createPerson(2L, "admin2@test.com");
@@ -86,7 +88,8 @@ class NegotiationSubmissionHandlerTest {
             negotiationId,
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     when(personRepository.findAllByAdminIsTrue()).thenReturn(Collections.emptyList());
 
@@ -107,7 +110,8 @@ class NegotiationSubmissionHandlerTest {
             negotiationId,
             NegotiationState.SUBMITTED,
             NegotiationState.IN_PROGRESS,
-            NegotiationEvent.APPROVE);
+            NegotiationEvent.APPROVE,
+            Set.of());
 
     // When
     handler.notify(event);
@@ -135,7 +139,12 @@ class NegotiationSubmissionHandlerTest {
     for (NegotiationState state : nonSubmittedStates) {
       NegotiationStateChangeEvent event =
           new NegotiationStateChangeEvent(
-              this, negotiationId, NegotiationState.SUBMITTED, state, NegotiationEvent.APPROVE);
+              this,
+              negotiationId,
+              NegotiationState.SUBMITTED,
+              state,
+              NegotiationEvent.APPROVE,
+              Set.of());
 
       // When
       handler.notify(event);
@@ -151,7 +160,8 @@ class NegotiationSubmissionHandlerTest {
             negotiationId,
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
     handler.notify(submittedEvent);
 
     verify(notificationService, times(1)).createNotifications(any());

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/notification/internal/NotificationListenerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/notification/internal/NotificationListenerTest.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -151,7 +152,8 @@ class NotificationListenerTest {
             "negotiation-123",
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     // When
     ReflectionTestUtils.invokeMethod(notificationListener, "onNewEvent", event);
@@ -209,7 +211,8 @@ class NotificationListenerTest {
             "negotiation-123",
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     // When
     ReflectionTestUtils.invokeMethod(notificationListener, "onNewEvent", event);
@@ -319,7 +322,8 @@ class NotificationListenerTest {
             "negotiation-123",
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     // When
     ReflectionTestUtils.invokeMethod(notificationListener, "onNewEvent", event);
@@ -376,14 +380,16 @@ class NotificationListenerTest {
             "negotiation-123",
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
     NegotiationStateChangeEvent negotiationEvent2 =
         new NegotiationStateChangeEvent(
             this,
             "negotiation-456",
             NegotiationState.SUBMITTED,
             NegotiationState.APPROVED,
-            NegotiationEvent.APPROVE);
+            NegotiationEvent.APPROVE,
+            Set.of());
     NewPostEvent postEvent1 = new NewPostEvent(this, "post-123", "negotiation-789", 111L, 222L);
     NewPostEvent postEvent2 = new NewPostEvent(this, "post-456", "negotiation-101", 333L, 444L);
 
@@ -457,7 +463,8 @@ class NotificationListenerTest {
             "negotiation-123",
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     // When
     ReflectionTestUtils.invokeMethod(notificationListener, "onNewEvent", event);
@@ -490,7 +497,8 @@ class NotificationListenerTest {
             "negotiation-123",
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     // When
     ReflectionTestUtils.invokeMethod(notificationListener, "dispatch", negotiationHandler, event);

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/unit/service/PersistStateChangeListenerTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/unit/service/PersistStateChangeListenerTest.java
@@ -1,0 +1,78 @@
+package eu.bbmri_eric.negotiator.unit.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import eu.bbmri_eric.negotiator.negotiation.NegotiationRepository;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationState;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.NegotiationStateChangeEvent;
+import eu.bbmri_eric.negotiator.negotiation.state_machine.negotiation.PersistStateChangeListener;
+import eu.bbmri_eric.negotiator.post.PostRepository;
+import eu.bbmri_eric.negotiator.user.PersonRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.state.State;
+import org.springframework.statemachine.transition.Transition;
+import org.springframework.statemachine.trigger.Trigger;
+
+@ExtendWith(MockitoExtension.class)
+class PersistStateChangeListenerTest {
+
+  @Mock private NegotiationRepository negotiationRepository;
+  @Mock private PersonRepository personRepository;
+  @Mock private PostRepository postRepository;
+  @Mock private ApplicationEventPublisher eventPublisher;
+
+  @Mock private State<String, String> state;
+  @Mock private Transition<String, String> transition;
+  @Mock private State<String, String> sourceState;
+  @Mock private Trigger<String, String> trigger;
+  @Mock private StateMachine<String, String> stateMachine;
+
+  private PersistStateChangeListener listener;
+
+  @BeforeEach
+  void setUp() {
+    listener =
+        new PersistStateChangeListener(
+            negotiationRepository, personRepository, postRepository, eventPublisher);
+  }
+
+  @Test
+  void onPersist_negotiationNotFound_publishesEventWithEmptyOrgIds() {
+    String negotiationId = "negotiation-unknown";
+
+    when(negotiationRepository.findDetailedById(negotiationId)).thenReturn(Optional.empty());
+    when(state.getId()).thenReturn(NegotiationState.IN_PROGRESS.name());
+    when(transition.getSource()).thenReturn(sourceState);
+    when(sourceState.getId()).thenReturn(NegotiationState.SUBMITTED.name());
+    when(transition.getTrigger()).thenReturn(trigger);
+    when(trigger.getEvent()).thenReturn(NegotiationEvent.START.name());
+
+    Message<String> message =
+        MessageBuilder.withPayload(NegotiationEvent.START.name())
+            .setHeader("negotiationId", negotiationId)
+            .build();
+
+    listener.onPersist(state, message, transition, stateMachine);
+
+    ArgumentCaptor<NegotiationStateChangeEvent> eventCaptor =
+        ArgumentCaptor.forClass(NegotiationStateChangeEvent.class);
+    verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+    NegotiationStateChangeEvent published = eventCaptor.getValue();
+    assertThat(published.getNegotiationId()).isEqualTo(negotiationId);
+    assertThat(published.getInvolvedOrganizationExternalIds()).isEmpty();
+  }
+}

--- a/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapperTest.java
+++ b/backend/src/test/java/eu/bbmri_eric/negotiator/webhook/event/WebhookEventMapperTest.java
@@ -17,6 +17,7 @@ import eu.bbmri_eric.negotiator.post.NewPostEvent;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEvent;
@@ -71,7 +72,8 @@ class WebhookEventMapperTest {
             "negotiation-2",
             NegotiationState.DRAFT,
             NegotiationState.SUBMITTED,
-            NegotiationEvent.SUBMIT);
+            NegotiationEvent.SUBMIT,
+            Set.of());
 
     Optional<WebhookPayloadEnvelope<?>> mapped = mapper.map(event);
 
@@ -90,7 +92,8 @@ class WebhookEventMapperTest {
             "negotiation-2",
             NegotiationState.SUBMITTED,
             NegotiationState.IN_PROGRESS,
-            NegotiationEvent.APPROVE);
+            NegotiationEvent.APPROVE,
+            Set.of("bbmri:DE:MHH"));
 
     Optional<WebhookPayloadEnvelope<?>> mapped = mapper.map(event);
 
@@ -103,7 +106,8 @@ class WebhookEventMapperTest {
                 "negotiation-2",
                 NegotiationState.SUBMITTED,
                 NegotiationState.IN_PROGRESS,
-                NegotiationEvent.APPROVE));
+                NegotiationEvent.APPROVE,
+                Set.of("bbmri:DE:MHH")));
   }
 
   @Test


### PR DESCRIPTION
### Description:

The negotiation.state.updated webhook payload now includes involvedOrganizationExternalIds — a set of external IDs of all organizations whose resources are part of the negotiation.

This field is required by the negotiator-link middleware to resolve the correct OrganizationConfig entry (which holds credentials) before making any secondary Negotiator API call. Without knowing which organization external IDs are involved, the middleware cannot identify which configured organization the webhook belongs to and has no credentials to fetch negotiation data or resources. With the IDs present in the payload, the middleware can immediately resolve the config; if none of the IDs match its YAML configuration, the event is silently discarded without any API call.

  Changes:
  - `NegotiationStateChangeEvent` carries the org external IDs collected from the negotiation's
    resources inside `PersistStateChangeListener.onPersist()`, which runs within a `@Transactional`
    boundary so lazy-loading is safe
  - `NegotiationStateUpdatedWebhookEvent` record extended with the new field; mapping strategy
    threads it through
  - Tests updated to compile with the new constructor parameter; `sendEvent_approveNewNegotiation_isOngoing`
    asserts the published event contains the correct org IDs; `publishNegotiationStateChangeEvent_dispatchesToActiveWebhooks` asserts the field is present in the serialized webhook JSON body

### Checklist:

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
