### PR TITLE
Fix: Info icon/status dropdown button openable when not updatable

### DIFF
--- a/frontend/src/components/OrganizationHeader.vue
+++ b/frontend/src/components/OrganizationHeader.vue
@@ -18,13 +18,13 @@
       </div>
 
       <!-- Status Dropdown -->
-      <div class="status-dropdown-container ms-auto" :data-org-id="orgId">
+      <div class="status-dropdown-container ms-auto" :data-org-id="orgId" v-if="org.status">
         <button
           type="button"
           class="status-box p-1 d-flex align-items-center btn"
           :aria-disabled="!canUpdateStatus"
           :tabindex="canUpdateStatus ? 0 : -1"
-          title="Select current status. The term Resource is abstract and can for example refer to biological samples, datasets or a service such as sequencing."
+          title="Select current status"
           @click.stop="onToggleDropdown"
         >
           <UiBadge :class="getStatusColor(org.status)" :icon="getStatusIcon(org.status)">

--- a/frontend/src/components/OrganizationHeader.vue
+++ b/frontend/src/components/OrganizationHeader.vue
@@ -22,6 +22,8 @@
         <button
           type="button"
           class="status-box p-1 d-flex align-items-center btn"
+          :aria-disabled="!canUpdateStatus"
+          :tabindex="canUpdateStatus ? 0 : -1"
           title="Select current status. The term Resource is abstract and can for example refer to biological samples, datasets or a service such as sequencing."
           @click.stop="onToggleDropdown"
         >
@@ -29,15 +31,12 @@
             {{ org.status?.replace(/_/g, ' ') || '' }}
           </UiBadge>
           <i
-            v-if="org.updatable && orgResourceStateOverride"
+            v-if="canUpdateStatus"
             class="bi icon-smaller mx-1"
             :class="dropdownVisible[orgId] ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
           />
         </button>
-        <ul
-          v-if="org.updatable && orgResourceStateOverride && dropdownVisible[orgId]"
-          class="dropdown-menu show"
-        >
+        <ul v-if="canUpdateStatus && dropdownVisible[orgId]" class="dropdown-menu show">
           <li
             v-for="state in sortedStates"
             :key="state.value"
@@ -57,7 +56,7 @@
 
 <script setup>
 import UiBadge from '@/components/ui/UiBadge.vue'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { getStatusColor, getStatusIcon } from '../composables/utils.js'
 import { useFeatureFlags } from '../composables/useFeatureFlags.js'
 
@@ -75,7 +74,10 @@ const emit = defineEmits(['toggle-dropdown', 'toggle-collapse', 'update-org-stat
 const isCollapsed = ref(false)
 const sanitizeId = (id) => id.replaceAll(':', '_')
 
+const canUpdateStatus = computed(() => props.org.updatable && orgResourceStateOverride)
+
 const onToggleDropdown = () => {
+  if (!canUpdateStatus.value) return
   emit('toggle-dropdown', props.orgId)
 }
 
@@ -130,5 +132,10 @@ const onUpdateOrgStatus = (state) => {
 /* Icon size */
 .icon-smaller {
   font-size: 0.8rem;
+}
+
+.status-box:focus {
+  background-color: #fafafa !important;
+  border-color: #fafafa !important;
 }
 </style>

--- a/frontend/src/components/OrganizationHeader.vue
+++ b/frontend/src/components/OrganizationHeader.vue
@@ -22,8 +22,7 @@
         <button
           type="button"
           class="status-box p-1 d-flex align-items-center btn"
-          :aria-disabled="!canUpdateStatus"
-          :tabindex="canUpdateStatus ? 0 : -1"
+          :disabled="!canUpdateStatus"
           title="Select current status"
           @click.stop="onToggleDropdown"
         >
@@ -134,8 +133,12 @@ const onUpdateOrgStatus = (state) => {
   font-size: 0.8rem;
 }
 
-.status-box:focus {
+.status-box {
   background-color: #fafafa !important;
   border-color: #fafafa !important;
+}
+
+.status-box:disabled {
+  opacity: 1 !important;
 }
 </style>


### PR DESCRIPTION
### Description:

##In OrganizationHeader.vue, the organization status button was always clickable and focusable, even when the status couldn't be updated (org.updatable false or no orgResourceStateOverride). The caret icon and dropdown menu were correctly hidden in that case, but the button itself still emitted toggle-dropdown on click and remained in the tab order, leading to a confusing/broken state.

##Changes
Extracted the repeated org.updatable && orgResourceStateOverride check into a canUpdateStatus computed.
onToggleDropdown now no-ops when canUpdateStatus is false.
Added aria-disabled and tabindex="-1" on the status button when not updatable, for accessibility and to remove it from keyboard navigation.
Added a focus style for .status-box.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

**Required for all pull requests:**
- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have removed all commented code
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
**If applicable to this PR:**
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
